### PR TITLE
Add Compose test for AnimationApp

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -47,6 +47,8 @@ dependencies {
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
     testImplementation(libs.junit)
+    testImplementation(platform(libs.androidx.compose.bom))
+    testImplementation(libs.androidx.ui.test.junit4)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/MainActivity.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/MainActivity.kt
@@ -15,12 +15,14 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.airbnb.lottie.compose.LottieAnimation
@@ -44,8 +46,9 @@ class MainActivity : ComponentActivity() {
 }
 
 @Composable
-fun AnimationApp(modifier: Modifier) {
+fun AnimationApp(modifier: Modifier, onIsPlayingChanged: (Boolean) -> Unit = {}) {
     var isPlaying by remember { mutableStateOf(false) }
+    LaunchedEffect(isPlaying) { onIsPlayingChanged(isPlaying) }
     val composition by rememberLottieComposition(spec = LottieCompositionSpec.RawRes(R.raw.animation_box))
 
     // To switch between the start and destination frames of the animation
@@ -72,8 +75,9 @@ fun AnimationApp(modifier: Modifier) {
             composition = composition,
             progress = { if (isPlaying) 0.23f + (progressNormal * 0.77f) else progressValue },
             modifier = Modifier.fillMaxSize()
+                .testTag("animation")
                 .clickable {
-                    isPlaying = true
+                    isPlaying = !isPlaying
                 }
         )
     }

--- a/app/src/test/java/com/cihat/egitim/lottieanimation/ExampleUnitTest.kt
+++ b/app/src/test/java/com/cihat/egitim/lottieanimation/ExampleUnitTest.kt
@@ -1,17 +1,31 @@
 package com.cihat.egitim.lottieanimation
 
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import org.junit.Assert.assertTrue
+import org.junit.Rule
 import org.junit.Test
 
-import org.junit.Assert.*
-
-/**
- * Example local unit test, which will execute on the development machine (host).
- *
- * See [testing documentation](http://d.android.com/tools/testing).
- */
 class ExampleUnitTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
     @Test
-    fun addition_isCorrect() {
-        assertEquals(4, 2 + 2)
+    fun animationClickTogglesIsPlaying() {
+        val isPlaying: MutableState<Boolean> = mutableStateOf(false)
+        composeRule.setContent {
+            AnimationApp(modifier = Modifier, onIsPlayingChanged = { isPlaying.value = it })
+        }
+
+        composeRule.onNodeWithTag("animation").performClick()
+
+        composeRule.runOnIdle {
+            assertTrue(isPlaying.value)
+        }
     }
 }
+


### PR DESCRIPTION
## Summary
- expose `isPlaying` through a lambda and tag the Lottie view for tests
- toggle play state on click and track via `LaunchedEffect`
- add Compose UI test dependencies
- replace example unit test with Compose test to check play state

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686981ca1cac832d89570f0d5ff7f891