### PR TITLE
Implement compose navigation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,6 +51,7 @@ dependencies {
     implementation(libs.androidx.material.icons.extended)
     implementation(libs.navigation.fragment.ktx)
     implementation(libs.navigation.ui.ktx)
+    implementation(libs.navigation.compose)
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.auth.ktx)
     implementation(libs.firebase.firestore.ktx)
@@ -63,5 +64,4 @@ dependencies {
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
 
-    implementation(libs.lottie)
-}
+    implementation(libs.lottie)}

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/MainActivity.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/MainActivity.kt
@@ -1,13 +1,26 @@
 package com.cihat.egitim.lottieanimation
 
 import android.os.Bundle
-import androidx.appcompat.app.AppCompatActivity
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.viewModels
+import com.cihat.egitim.lottieanimation.ui.navigation.AppNavHost
+import com.cihat.egitim.lottieanimation.viewmodel.AuthViewModel
+import com.cihat.egitim.lottieanimation.viewmodel.QuizViewModel
+import com.cihat.egitim.lottieanimation.ui.theme.LottieAnimationTheme
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : ComponentActivity() {
+    private val authViewModel: AuthViewModel by viewModels()
+    private val quizViewModel: QuizViewModel by viewModels()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
-        setContentView(R.layout.activity_main)
+        setContent {
+            LottieAnimationTheme {
+                AppNavHost(authViewModel, quizViewModel)
+            }
+        }
     }
 }

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/components/AppScaffold.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/components/AppScaffold.kt
@@ -6,6 +6,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Home
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -17,7 +18,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 
-enum class BottomTab { PROFILE, EXPLORE }
+enum class BottomTab { PROFILE, HOME, EXPLORE }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -50,6 +51,12 @@ fun AppScaffold(
                         onClick = { onTabSelected(BottomTab.PROFILE) },
                         icon = { Icon(Icons.Default.Person, contentDescription = "Profile") },
                         label = { Text("Profile") }
+                    )
+                    NavigationBarItem(
+                        selected = tab == BottomTab.HOME,
+                        onClick = { onTabSelected(BottomTab.HOME) },
+                        icon = { Icon(Icons.Default.Home, contentDescription = "Home") },
+                        label = { Text("Home") }
                     )
                     NavigationBarItem(
                         selected = tab == BottomTab.EXPLORE,

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/navigation/AppNavHost.kt
@@ -1,0 +1,215 @@
+package com.cihat.egitim.lottieanimation.ui.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.navigation.NavType
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
+import com.cihat.egitim.lottieanimation.viewmodel.AuthViewModel
+import com.cihat.egitim.lottieanimation.viewmodel.QuizViewModel
+import com.cihat.egitim.lottieanimation.ui.components.BottomTab
+import com.cihat.egitim.lottieanimation.ui.screens.AddQuestionScreen
+import com.cihat.egitim.lottieanimation.ui.screens.AuthScreen
+import com.cihat.egitim.lottieanimation.ui.screens.BoxListScreen
+import com.cihat.egitim.lottieanimation.ui.screens.HomeFeedScreen
+import com.cihat.egitim.lottieanimation.ui.screens.QuestionListScreen
+import com.cihat.egitim.lottieanimation.ui.screens.QuizListScreen
+import com.cihat.egitim.lottieanimation.ui.screens.QuizScreen
+import com.cihat.egitim.lottieanimation.ui.screens.SetupScreen
+import com.cihat.egitim.lottieanimation.ui.screens.SplashScreen
+
+sealed class Screen(val route: String) {
+    data object Splash : Screen("splash")
+    data object Auth : Screen("auth")
+    data object Setup : Screen("setup")
+    data object QuizList : Screen("quizList")
+    data object BoxList : Screen("boxList")
+    data object AddQuestion : Screen("addQuestion")
+    data object HomeFeed : Screen("homeFeed")
+    data object Quiz : Screen("quiz")
+    data object QuestionList : Screen("questionList/{boxIndex}") {
+        const val boxArg = "boxIndex"
+        fun createRoute(boxIndex: Int) = "questionList/$boxIndex"
+    }
+}
+
+@Composable
+fun AppNavHost(
+    authViewModel: AuthViewModel,
+    quizViewModel: QuizViewModel
+) {
+    val navController = rememberNavController()
+    NavHost(navController = navController, startDestination = Screen.Splash.route) {
+        composable(Screen.Splash.route) {
+            SplashScreen()
+            LaunchedEffect(Unit) {
+                kotlinx.coroutines.delay(2000)
+                if (authViewModel.currentUser != null) {
+                    navController.navigate(Screen.Setup.route) {
+                        popUpTo(Screen.Splash.route) { inclusive = true }
+                    }
+                } else {
+                    navController.navigate(Screen.Auth.route) {
+                        popUpTo(Screen.Splash.route) { inclusive = true }
+                    }
+                }
+            }
+        }
+        composable(Screen.Auth.route) {
+            AuthScreen(
+                onLogin = { e, p ->
+                    authViewModel.login(e, p) { success ->
+                        if (success) {
+                            navController.navigate(Screen.Setup.route) {
+                                popUpTo(Screen.Auth.route) { inclusive = true }
+                            }
+                        }
+                    }
+                },
+                onRegister = { e, p ->
+                    authViewModel.register(e, p) { success ->
+                        if (success) {
+                            navController.navigate(Screen.Setup.route) {
+                                popUpTo(Screen.Auth.route) { inclusive = true }
+                            }
+                        }
+                    }
+                }
+            )
+        }
+        composable(Screen.Setup.route) {
+            SetupScreen(
+                onStart = { count ->
+                    quizViewModel.createQuiz("Quiz ${quizViewModel.quizzes.size + 1}", count)
+                    navController.navigate(Screen.QuizList.route)
+                },
+                onBack = { navController.popBackStack() }
+            )
+        }
+        composable(Screen.QuizList.route) {
+            QuizListScreen(
+                quizzes = quizViewModel.quizzes,
+                onQuiz = { quizIdx, boxIdx ->
+                    quizViewModel.setCurrentQuiz(quizIdx)
+                    if (quizViewModel.startQuiz(boxIdx)) {
+                        navController.navigate(Screen.Quiz.route)
+                    } else {
+                        android.widget.Toast.makeText(
+                            navController.context,
+                            "Bu kutuda soru yok",
+                            android.widget.Toast.LENGTH_SHORT
+                        ).show()
+                    }
+                },
+                onView = { quizIdx, boxIdx ->
+                    quizViewModel.setCurrentQuiz(quizIdx)
+                    navController.navigate(Screen.QuestionList.createRoute(boxIdx))
+                },
+                onAdd = { quizIdx ->
+                    quizViewModel.setCurrentQuiz(quizIdx)
+                    navController.navigate(Screen.AddQuestion.route)
+                },
+                onLogout = {
+                    authViewModel.logout()
+                    navController.navigate(Screen.Auth.route) {
+                        popUpTo(Screen.QuizList.route) { inclusive = true }
+                    }
+                },
+                onTab = { tab ->
+                    when (tab) {
+                        BottomTab.PROFILE -> {}
+                        BottomTab.EXPLORE -> navController.navigate(Screen.HomeFeed.route)
+                    }
+                }
+            )
+        }
+        composable(Screen.BoxList.route) {
+            BoxListScreen(
+                quizName = quizViewModel.currentQuizName,
+                boxes = quizViewModel.boxes,
+                onQuiz = { index ->
+                    if (quizViewModel.startQuiz(index)) {
+                        navController.navigate(Screen.Quiz.route)
+                    } else {
+                        android.widget.Toast.makeText(
+                            navController.context,
+                            "Bu kutuda soru yok",
+                            android.widget.Toast.LENGTH_SHORT
+                        ).show()
+                    }
+                },
+                onAdd = { navController.navigate(Screen.AddQuestion.route) },
+                onView = { index -> navController.navigate(Screen.QuestionList.createRoute(index)) },
+                onBack = { navController.popBackStack() },
+                onLogout = {
+                    authViewModel.logout()
+                    navController.navigate(Screen.Auth.route) {
+                        popUpTo(Screen.BoxList.route) { inclusive = true }
+                    }
+                },
+                onTab = { tab ->
+                    when (tab) {
+                        BottomTab.PROFILE -> navController.navigate(Screen.QuizList.route)
+                        BottomTab.EXPLORE -> navController.navigate(Screen.HomeFeed.route)
+                    }
+                }
+            )
+        }
+        composable(Screen.AddQuestion.route) {
+            AddQuestionScreen(
+                boxCount = quizViewModel.boxes.size,
+                onAdd = { q, a, topic, sub, box ->
+                    quizViewModel.addQuestion(q, a, topic, sub, box)
+                },
+                onBack = { navController.popBackStack() },
+                onDone = { navController.popBackStack() }
+            )
+        }
+        composable(Screen.HomeFeed.route) {
+            HomeFeedScreen(
+                quizzes = quizViewModel.publicQuizzes,
+                onImport = { index ->
+                    quizViewModel.importQuiz(quizViewModel.publicQuizzes[index])
+                    android.widget.Toast.makeText(
+                        navController.context,
+                        "Quiz imported",
+                        android.widget.Toast.LENGTH_SHORT
+                    ).show()
+                    navController.navigate(Screen.QuizList.route)
+                },
+                onBack = { navController.popBackStack() },
+                onTab = { tab ->
+                    when (tab) {
+                        BottomTab.PROFILE -> navController.navigate(Screen.QuizList.route)
+                        BottomTab.EXPLORE -> {}
+                    }
+                }
+            )
+        }
+        composable(Screen.Quiz.route) {
+            QuizScreen(
+                question = quizViewModel.currentQuestion,
+                isAnswerVisible = quizViewModel.isAnswerVisible,
+                onReveal = { quizViewModel.revealAnswer() },
+                onAnswer = { correct ->
+                    val more = quizViewModel.onAnswerSelected(correct)
+                    if (!more) navController.popBackStack()
+                },
+                onQuit = { navController.popBackStack() }
+            )
+        }
+        composable(
+            route = Screen.QuestionList.route,
+            arguments = listOf(navArgument(Screen.QuestionList.boxArg) { type = NavType.IntType })
+        ) { backStackEntry ->
+            val index = backStackEntry.arguments?.getInt(Screen.QuestionList.boxArg) ?: 0
+            val questions = quizViewModel.boxes.getOrNull(index).orEmpty()
+            QuestionListScreen(
+                questions = questions,
+                onBack = { navController.popBackStack() }
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/navigation/AppNavHost.kt
@@ -1,7 +1,6 @@
 package com.cihat.egitim.lottieanimation.ui.navigation
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -19,10 +18,8 @@ import com.cihat.egitim.lottieanimation.ui.screens.QuestionListScreen
 import com.cihat.egitim.lottieanimation.ui.screens.QuizListScreen
 import com.cihat.egitim.lottieanimation.ui.screens.QuizScreen
 import com.cihat.egitim.lottieanimation.ui.screens.SetupScreen
-import com.cihat.egitim.lottieanimation.ui.screens.SplashScreen
 
 sealed class Screen(val route: String) {
-    data object Splash : Screen("splash")
     data object Auth : Screen("auth")
     data object Setup : Screen("setup")
     data object QuizList : Screen("quizList")
@@ -43,22 +40,7 @@ fun AppNavHost(
     quizViewModel: QuizViewModel
 ) {
     val navController = rememberNavController()
-    NavHost(navController = navController, startDestination = Screen.Splash.route) {
-        composable(Screen.Splash.route) {
-            SplashScreen()
-            LaunchedEffect(Unit) {
-                kotlinx.coroutines.delay(2000)
-                if (authViewModel.currentUser != null) {
-                    navController.navigate(Screen.Profile.route) {
-                        popUpTo(Screen.Splash.route) { inclusive = true }
-                    }
-                } else {
-                    navController.navigate(Screen.Auth.route) {
-                        popUpTo(Screen.Splash.route) { inclusive = true }
-                    }
-                }
-            }
-        }
+    NavHost(navController = navController, startDestination = Screen.QuizList.route) {
         composable(Screen.Auth.route) {
             AuthScreen(
                 onLogin = { e, p ->
@@ -92,6 +74,7 @@ fun AppNavHost(
                 onTab = { tab ->
                     when (tab) {
                         BottomTab.PROFILE -> navController.navigate(Screen.Profile.route)
+                        BottomTab.HOME -> navController.navigate(Screen.QuizList.route)
                         BottomTab.EXPLORE -> navController.navigate(Screen.HomeFeed.route)
                     }
                 }
@@ -138,6 +121,7 @@ fun AppNavHost(
                 onTab = { tab ->
                     when (tab) {
                         BottomTab.PROFILE -> navController.navigate(Screen.Profile.route)
+                        BottomTab.HOME -> navController.navigate(Screen.QuizList.route)
                         BottomTab.EXPLORE -> navController.navigate(Screen.HomeFeed.route)
                     }
                 }
@@ -170,6 +154,7 @@ fun AppNavHost(
                 onTab = { tab ->
                     when (tab) {
                         BottomTab.PROFILE -> navController.navigate(Screen.Profile.route)
+                        BottomTab.HOME -> navController.navigate(Screen.QuizList.route)
                         BottomTab.EXPLORE -> navController.navigate(Screen.HomeFeed.route)
                     }
                 }
@@ -201,6 +186,7 @@ fun AppNavHost(
                 onTab = { tab ->
                     when (tab) {
                         BottomTab.PROFILE -> navController.navigate(Screen.Profile.route)
+                        BottomTab.HOME -> navController.navigate(Screen.QuizList.route)
                         BottomTab.EXPLORE -> {}
                     }
                 }

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/navigation/AppNavHost.kt
@@ -14,6 +14,7 @@ import com.cihat.egitim.lottieanimation.ui.screens.AddQuestionScreen
 import com.cihat.egitim.lottieanimation.ui.screens.AuthScreen
 import com.cihat.egitim.lottieanimation.ui.screens.BoxListScreen
 import com.cihat.egitim.lottieanimation.ui.screens.HomeFeedScreen
+import com.cihat.egitim.lottieanimation.ui.screens.ProfileScreen
 import com.cihat.egitim.lottieanimation.ui.screens.QuestionListScreen
 import com.cihat.egitim.lottieanimation.ui.screens.QuizListScreen
 import com.cihat.egitim.lottieanimation.ui.screens.QuizScreen
@@ -25,6 +26,7 @@ sealed class Screen(val route: String) {
     data object Auth : Screen("auth")
     data object Setup : Screen("setup")
     data object QuizList : Screen("quizList")
+    data object Profile : Screen("profile")
     data object BoxList : Screen("boxList")
     data object AddQuestion : Screen("addQuestion")
     data object HomeFeed : Screen("homeFeed")
@@ -47,7 +49,7 @@ fun AppNavHost(
             LaunchedEffect(Unit) {
                 kotlinx.coroutines.delay(2000)
                 if (authViewModel.currentUser != null) {
-                    navController.navigate(Screen.Setup.route) {
+                    navController.navigate(Screen.Profile.route) {
                         popUpTo(Screen.Splash.route) { inclusive = true }
                     }
                 } else {
@@ -62,7 +64,7 @@ fun AppNavHost(
                 onLogin = { e, p ->
                     authViewModel.login(e, p) { success ->
                         if (success) {
-                            navController.navigate(Screen.Setup.route) {
+                            navController.navigate(Screen.Profile.route) {
                                 popUpTo(Screen.Auth.route) { inclusive = true }
                             }
                         }
@@ -71,10 +73,26 @@ fun AppNavHost(
                 onRegister = { e, p ->
                     authViewModel.register(e, p) { success ->
                         if (success) {
-                            navController.navigate(Screen.Setup.route) {
+                            navController.navigate(Screen.Profile.route) {
                                 popUpTo(Screen.Auth.route) { inclusive = true }
                             }
                         }
+                    }
+                }
+            )
+        }
+        composable(Screen.Profile.route) {
+            ProfileScreen(
+                onPro = {},
+                onAuth = { navController.navigate(Screen.Auth.route) },
+                onSettings = {},
+                onFolders = { navController.navigate(Screen.QuizList.route) },
+                onSupport = {},
+                onRate = {},
+                onTab = { tab ->
+                    when (tab) {
+                        BottomTab.PROFILE -> navController.navigate(Screen.Profile.route)
+                        BottomTab.EXPLORE -> navController.navigate(Screen.HomeFeed.route)
                     }
                 }
             )
@@ -119,7 +137,7 @@ fun AppNavHost(
                 },
                 onTab = { tab ->
                     when (tab) {
-                        BottomTab.PROFILE -> {}
+                        BottomTab.PROFILE -> navController.navigate(Screen.Profile.route)
                         BottomTab.EXPLORE -> navController.navigate(Screen.HomeFeed.route)
                     }
                 }
@@ -151,7 +169,7 @@ fun AppNavHost(
                 },
                 onTab = { tab ->
                     when (tab) {
-                        BottomTab.PROFILE -> navController.navigate(Screen.QuizList.route)
+                        BottomTab.PROFILE -> navController.navigate(Screen.Profile.route)
                         BottomTab.EXPLORE -> navController.navigate(Screen.HomeFeed.route)
                     }
                 }
@@ -182,7 +200,7 @@ fun AppNavHost(
                 onBack = { navController.popBackStack() },
                 onTab = { tab ->
                     when (tab) {
-                        BottomTab.PROFILE -> navController.navigate(Screen.QuizList.route)
+                        BottomTab.PROFILE -> navController.navigate(Screen.Profile.route)
                         BottomTab.EXPLORE -> {}
                     }
                 }

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/AddQuestionFragment.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/AddQuestionFragment.kt
@@ -68,7 +68,7 @@ class AddQuestionFragment : Fragment() {
 }
 
 @Composable
-private fun AddQuestionScreen(
+fun AddQuestionScreen(
     boxCount: Int,
     onAdd: (String, String, String, String, Int) -> Unit,
     onBack: () -> Unit,

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/AuthFragment.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/AuthFragment.kt
@@ -62,7 +62,7 @@ class AuthFragment : Fragment() {
 }
 
 @Composable
-private fun AuthScreen(
+fun AuthScreen(
     onLogin: (String, String) -> Unit,
     onRegister: (String, String) -> Unit
 ) {

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/BoxListFragment.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/BoxListFragment.kt
@@ -104,7 +104,7 @@ fun BoxListScreen(
         title = quizName,
         showBack = true,
         onBack = onBack,
-        bottomTab = BottomTab.PROFILE,
+        bottomTab = BottomTab.HOME,
         onTabSelected = onTab
     ) {
         Column(

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/BoxListFragment.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/BoxListFragment.kt
@@ -90,7 +90,7 @@ class BoxListFragment : Fragment() {
 }
 
 @Composable
-private fun BoxListScreen(
+fun BoxListScreen(
     quizName: String,
     boxes: List<List<*>>,
     onQuiz: (Int) -> Unit,

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/BoxListFragment.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/BoxListFragment.kt
@@ -31,6 +31,7 @@ import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
+import com.cihat.egitim.lottieanimation.R
 import com.cihat.egitim.lottieanimation.ui.theme.LottieAnimationTheme
 import com.cihat.egitim.lottieanimation.ui.components.AppScaffold
 import com.cihat.egitim.lottieanimation.ui.components.BottomTab
@@ -78,8 +79,9 @@ class BoxListFragment : Fragment() {
                         },
                         onTab = { tab ->
                             when (tab) {
-                                BottomTab.PROFILE -> findNavController().navigate(com.cihat.egitim.lottieanimation.R.id.quizListFragment)
-                                BottomTab.EXPLORE -> findNavController().navigate(com.cihat.egitim.lottieanimation.R.id.homeFeedFragment)
+                                BottomTab.PROFILE -> findNavController().navigate(R.id.quizListFragment)
+                                BottomTab.EXPLORE -> findNavController().navigate(R.id.homeFeedFragment)
+                                BottomTab.HOME -> TODO()
                             }
                         }
                     )

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/HomeFeedFragment.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/HomeFeedFragment.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.unit.dp
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
+import com.cihat.egitim.lottieanimation.R
 import com.cihat.egitim.lottieanimation.ui.theme.LottieAnimationTheme
 import com.cihat.egitim.lottieanimation.ui.components.AppScaffold
 import com.cihat.egitim.lottieanimation.ui.components.BottomTab
@@ -46,8 +47,9 @@ class HomeFeedFragment : Fragment() {
                         onBack = { findNavController().navigateUp() },
                         onTab = { tab ->
                             when (tab) {
-                                BottomTab.PROFILE -> findNavController().navigate(com.cihat.egitim.lottieanimation.R.id.quizListFragment)
+                                BottomTab.PROFILE -> findNavController().navigate(R.id.quizListFragment)
                                 BottomTab.EXPLORE -> {}
+                                BottomTab.HOME -> TODO()
                             }
                         }
                     )

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/HomeFeedFragment.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/HomeFeedFragment.kt
@@ -58,7 +58,7 @@ class HomeFeedFragment : Fragment() {
 }
 
 @Composable
-private fun HomeFeedScreen(
+fun HomeFeedScreen(
     quizzes: List<com.cihat.egitim.lottieanimation.data.PublicQuiz>,
     onImport: (Int) -> Unit,
     onBack: () -> Unit,

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/ProfileScreen.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/ProfileScreen.kt
@@ -1,0 +1,74 @@
+package com.cihat.egitim.lottieanimation.ui.screens
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.material.icons.filled.Chat
+import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.ThumbUp
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.cihat.egitim.lottieanimation.ui.components.AppScaffold
+import com.cihat.egitim.lottieanimation.ui.components.BottomTab
+
+@Composable
+fun ProfileScreen(
+    onPro: () -> Unit,
+    onAuth: () -> Unit,
+    onSettings: () -> Unit,
+    onFolders: () -> Unit,
+    onSupport: () -> Unit,
+    onRate: () -> Unit,
+    onTab: (BottomTab) -> Unit
+) {
+    AppScaffold(
+        title = "Profile",
+        showBack = false,
+        onBack = {},
+        bottomTab = BottomTab.PROFILE,
+        onTabSelected = onTab
+    ) {
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            item { ProfileItem(Icons.Default.Star, "Pro Ol", onPro) }
+            item { ProfileItem(Icons.Default.AccountCircle, "Giriş/Kayıt", onAuth) }
+            item { ProfileItem(Icons.Default.Settings, "Ayarlar", onSettings) }
+            item { ProfileItem(Icons.Default.Folder, "Klasörlerim", onFolders) }
+            item { ProfileItem(Icons.Default.Chat, "Canlı Destek", onSupport) }
+            item { ProfileItem(Icons.Default.ThumbUp, "Google Play'de Oy Ver", onRate) }
+        }
+    }
+}
+
+@Composable
+private fun ProfileItem(icon: androidx.compose.ui.graphics.vector.ImageVector, text: String, onClick: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onClick() }
+            .padding(vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(icon, contentDescription = null)
+        Spacer(modifier = Modifier.width(16.dp))
+        Text(text)
+    }
+}

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/QuestionListFragment.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/QuestionListFragment.kt
@@ -46,7 +46,7 @@ class QuestionListFragment : Fragment() {
 }
 
 @Composable
-private fun QuestionListScreen(
+fun QuestionListScreen(
     questions: List<com.cihat.egitim.lottieanimation.data.Question>,
     onBack: () -> Unit
 ) {

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/QuizFragment.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/QuizFragment.kt
@@ -72,7 +72,7 @@ class QuizFragment : Fragment() {
 }
 
 @Composable
-private fun QuizScreen(
+fun QuizScreen(
     question: com.cihat.egitim.lottieanimation.data.Question?,
     isAnswerVisible: Boolean,
     onReveal: () -> Unit,

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/QuizListFragment.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/QuizListFragment.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.unit.dp
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
+import com.cihat.egitim.lottieanimation.R
 import com.cihat.egitim.lottieanimation.ui.theme.LottieAnimationTheme
 import com.cihat.egitim.lottieanimation.ui.components.AppScaffold
 import com.cihat.egitim.lottieanimation.ui.components.BottomTab
@@ -81,7 +82,8 @@ class QuizListFragment : Fragment() {
                         onTab = { tab ->
                             when (tab) {
                                 BottomTab.PROFILE -> {}
-                                BottomTab.EXPLORE -> findNavController().navigate(com.cihat.egitim.lottieanimation.R.id.homeFeedFragment)
+                                BottomTab.EXPLORE -> findNavController().navigate(R.id.homeFeedFragment)
+                                BottomTab.HOME -> TODO()
                             }
                         }
                     )
@@ -131,72 +133,73 @@ fun QuizListScreen(
                     itemsIndexed(quizzes) { quizIndex, quiz ->
                         var expanded by remember { mutableStateOf(false) }
                         Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(vertical = 8.dp)
-                    ) {
-                        Row(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .clickable { expanded = !expanded }
-                                .padding(8.dp),
-                            verticalAlignment = Alignment.CenterVertically
+                                .padding(vertical = 8.dp)
                         ) {
-                            Text(text = quiz.name, modifier = Modifier.weight(1f))
-                            Icon(
-                                imageVector = if (expanded) Icons.Default.ArrowDropUp else Icons.Default.ArrowDropDown,
-                                contentDescription = null
-                            )
-                        }
-                        if (expanded) {
-                            Column(
+                            Row(
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .padding(8.dp)
+                                    .clickable { expanded = !expanded }
+                                    .padding(8.dp),
+                                verticalAlignment = Alignment.CenterVertically
                             ) {
-                                quiz.boxes.chunked(2).forEachIndexed { rowIndex, pair ->
-                                    Row(
-                                        modifier = Modifier.fillMaxWidth(),
-                                        horizontalArrangement = Arrangement.spacedBy(8.dp)
-                                    ) {
-                                        pair.forEachIndexed { colIndex, box ->
-                                            val boxIndex = rowIndex * 2 + colIndex
-                                            Box(
-                                                modifier = Modifier
-                                                    .weight(1f)
-                                                    .aspectRatio(1f)
-                                                    .clickable { onView(quizIndex, boxIndex) }
-                                                    .padding(4.dp)
-                                                    .border(BorderStroke(1.dp, Color.Gray), RoundedCornerShape(4.dp)),
-                                                contentAlignment = Alignment.Center
-                                            ) {
-                                                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                                                    Text(text = "Box ${boxIndex + 1}")
-                                                    Text(text = "${box.size} soru")
-                                                    Spacer(modifier = Modifier.height(4.dp))
-                                                    Button(onClick = { onQuiz(quizIndex, boxIndex) }) { Text("Quiz") }
+                                Text(text = quiz.name, modifier = Modifier.weight(1f))
+                                Icon(
+                                    imageVector = if (expanded) Icons.Default.ArrowDropUp else Icons.Default.ArrowDropDown,
+                                    contentDescription = null
+                                )
+                            }
+                            if (expanded) {
+                                Column(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(8.dp)
+                                ) {
+                                    quiz.boxes.chunked(2).forEachIndexed { rowIndex, pair ->
+                                        Row(
+                                            modifier = Modifier.fillMaxWidth(),
+                                            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                                        ) {
+                                            pair.forEachIndexed { colIndex, box ->
+                                                val boxIndex = rowIndex * 2 + colIndex
+                                                Box(
+                                                    modifier = Modifier
+                                                        .weight(1f)
+                                                        .aspectRatio(1f)
+                                                        .clickable { onView(quizIndex, boxIndex) }
+                                                        .padding(4.dp)
+                                                        .border(BorderStroke(1.dp, Color.Gray), RoundedCornerShape(4.dp)),
+                                                    contentAlignment = Alignment.Center
+                                                ) {
+                                                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                                                        Text(text = "Box ${boxIndex + 1}")
+                                                        Text(text = "${box.size} soru")
+                                                        Spacer(modifier = Modifier.height(4.dp))
+                                                        Button(onClick = { onQuiz(quizIndex, boxIndex) }) { Text("Quiz") }
+                                                    }
                                                 }
                                             }
+                                            if (pair.size == 1) {
+                                                Spacer(modifier = Modifier.weight(1f))
+                                            }
                                         }
-                                        if (pair.size == 1) {
-                                            Spacer(modifier = Modifier.weight(1f))
-                                        }
+                                        Spacer(modifier = Modifier.height(8.dp))
                                     }
-                                    Spacer(modifier = Modifier.height(8.dp))
                                 }
+                                Button(
+                                    onClick = { onAdd(quizIndex) },
+                                    modifier = Modifier
+                                        .padding(top = 8.dp)
+                                        .align(Alignment.CenterHorizontally)
+                                ) { Text("Add Question") }
                             }
-                            Button(
-                                onClick = { onAdd(quizIndex) },
-                                modifier = Modifier
-                                    .padding(top = 8.dp)
-                                    .align(Alignment.CenterHorizontally)
-                            ) { Text("Add Question") }
                         }
                     }
                 }
-            }
-            Button(onClick = onLogout, modifier = Modifier.padding(top = 8.dp)) {
-                Text("Logout")
+                Button(onClick = onLogout, modifier = Modifier.padding(top = 8.dp)) {
+                    Text("Logout")
+                }
             }
         }
     }

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/QuizListFragment.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/QuizListFragment.kt
@@ -103,7 +103,7 @@ class QuizListFragment : Fragment() {
 }
 
 @Composable
-private fun QuizListScreen(
+fun QuizListScreen(
     quizzes: List<com.cihat.egitim.lottieanimation.data.UserQuiz>,
     onQuiz: (Int, Int) -> Unit,
     onView: (Int, Int) -> Unit,

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/QuizListFragment.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/QuizListFragment.kt
@@ -115,7 +115,7 @@ fun QuizListScreen(
         title = "My Quizzes",
         showBack = false,
         onBack = {},
-        bottomTab = BottomTab.PROFILE,
+        bottomTab = BottomTab.HOME,
         onTabSelected = onTab
     ) {
         Column(
@@ -124,10 +124,13 @@ fun QuizListScreen(
                 .padding(16.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            LazyColumn(modifier = Modifier.weight(1f)) {
-                itemsIndexed(quizzes) { quizIndex, quiz ->
-                    var expanded by remember { mutableStateOf(false) }
-                    Column(
+            if (quizzes.isEmpty()) {
+                androidx.compose.material3.Text("Henüz quiziniz yok")
+            } else {
+                LazyColumn(modifier = Modifier.weight(1f)) {
+                    itemsIndexed(quizzes) { quizIndex, quiz ->
+                        var expanded by remember { mutableStateOf(false) }
+                        Column(
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(vertical = 8.dp)

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/SetupFragment.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/SetupFragment.kt
@@ -57,7 +57,7 @@ class SetupFragment : Fragment() {
 }
 
 @Composable
-private fun SetupScreen(
+fun SetupScreen(
     onStart: (Int) -> Unit,
     onBack: () -> Unit
 ) {

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/SplashFragment.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/SplashFragment.kt
@@ -43,7 +43,7 @@ class SplashFragment : Fragment() {
 }
 
 @Composable
-private fun SplashScreen() {
+fun SplashScreen() {
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         Text("LOGO")
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,6 +38,7 @@ androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "l
 lottie = { group = "com.airbnb.android", name = "lottie-compose", version.ref = "lottie-ver" }
 navigation-fragment-ktx = { group = "androidx.navigation", name = "navigation-fragment-ktx", version.ref = "navigation" }
 navigation-ui-ktx = { group = "androidx.navigation", name = "navigation-ui-ktx", version.ref = "navigation" }
+navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigation" }
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
 firebase-auth-ktx = { group = "com.google.firebase", name = "firebase-auth-ktx" }
 firebase-firestore-ktx = { group = "com.google.firebase", name = "firebase-firestore-ktx" }


### PR DESCRIPTION
## Summary
- add `navigation-compose` library
- create `AppNavHost` with routes and nav controller
- switch `MainActivity` to Compose and host `AppNavHost`
- expose screen composables for navigation

## Testing
- `./gradlew assembleDebug` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686d6377065c832d9123e6db905a48d0