### PR TITLE
Add logo to splash and auth screens

### DIFF
--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/AuthFragment.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/AuthFragment.kt
@@ -97,7 +97,7 @@ fun AuthScreen(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Image(
-                painter = painterResource(id = R.drawable.ic_launcher_foreground),
+                painter = painterResource(id = R.mipmap.ic_launcher_foreground),
                 contentDescription = null,
                 modifier = Modifier.size(96.dp)
             )

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/AuthFragment.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/AuthFragment.kt
@@ -97,9 +97,9 @@ fun AuthScreen(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Image(
-                painter = painterResource(id = R.mipmap.ic_launcher_foreground),
+                painter = painterResource(id = R.drawable.ic_launcher_foreground),
                 contentDescription = null,
-                modifier = Modifier.size(96.dp)
+                modifier = Modifier.size(150.dp)
             )
             Spacer(Modifier.height(24.dp))
             Text(

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/SplashFragment.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/SplashFragment.kt
@@ -6,11 +6,15 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
@@ -45,6 +49,10 @@ class SplashFragment : Fragment() {
 @Composable
 fun SplashScreen() {
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Text("LOGO")
+        Image(
+            painter = painterResource(id = com.cihat.egitim.lottieanimation.R.mipmap.ic_launcher_foreground),
+            contentDescription = null,
+            modifier = Modifier.size(128.dp)
+        )
     }
 }

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/SplashFragment.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/SplashFragment.kt
@@ -50,9 +50,9 @@ class SplashFragment : Fragment() {
 fun SplashScreen() {
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         Image(
-            painter = painterResource(id = com.cihat.egitim.lottieanimation.R.mipmap.ic_launcher_foreground),
+            painter = painterResource(id = com.cihat.egitim.lottieanimation.R.drawable.ic_launcher_foreground),
             contentDescription = null,
-            modifier = Modifier.size(128.dp)
+            modifier = Modifier.size(192.dp)
         )
     }
 }


### PR DESCRIPTION
## Summary
- show the app logo on the splash screen
- show the app logo on the login/register screen

## Testing
- `./gradlew test --quiet` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686eb9d4a5a0832d8a19cc1732775ac9