### PR TITLE
Improve swipe behavior for quiz list items

### DIFF
--- a/app/src/main/java/com/cihat/egitim/lottieanimation/data/UserQuiz.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/data/UserQuiz.kt
@@ -4,6 +4,7 @@ package com.cihat.egitim.lottieanimation.data
  * Represents a quiz owned by the current user. Each quiz holds its own boxes.
  */
 data class UserQuiz(
+    val id: Int,
     val name: String,
     val boxes: MutableList<MutableList<Question>>
 )

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/QuizListScreen.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/QuizListScreen.kt
@@ -93,12 +93,12 @@ fun QuizListScreen(
                     // tries to read a missing index from the list.
                     itemsIndexed(
                         items = quizzes,
-                        key = { _, quiz -> quiz.name }
+                        key = { _, quiz -> quiz.id }
                     ) { quizIndex, quiz ->
-                        var expanded by remember { mutableStateOf(false) }
-                        var showRename by remember { mutableStateOf(false) }
-                        var showDelete by remember { mutableStateOf(false) }
-                        var newName by remember { mutableStateOf(quiz.name) }
+                        var expanded by remember(quiz.id) { mutableStateOf(false) }
+                        var showRename by remember(quiz.id) { mutableStateOf(false) }
+                        var showDelete by remember(quiz.id) { mutableStateOf(false) }
+                        var newName by remember(quiz.id) { mutableStateOf(quiz.name) }
                         val scope = rememberCoroutineScope()
                         val actionWidth = 72.dp
                         val swipeState = rememberSwipeableState(0)

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/QuizListScreen.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/QuizListScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/QuizListScreen.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/QuizListScreen.kt
@@ -105,6 +105,7 @@ fun QuizListScreen(
                         Box(
                             modifier = Modifier
                                 .fillMaxWidth()
+                                .clipToBounds()
                                 .swipeable(
                                     state = swipeState,
                                     anchors = mapOf(0f to 0, -maxOffset to 1),
@@ -144,6 +145,7 @@ fun QuizListScreen(
                             Column(
                                 modifier = Modifier
                                     .offset { IntOffset(swipeState.offset.value.roundToInt(), 0) }
+                                    .background(Color.White)
                                     .fillMaxWidth()
                                     .padding(vertical = 8.dp)
                             ) {

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/QuizListScreen.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/QuizListScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -46,6 +47,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
@@ -95,6 +97,9 @@ fun QuizListScreen(
                         val swipeState = rememberSwipeableState(0)
                         val maxOffset = with(LocalDensity.current) { (actionWidth * 2).toPx() }
 
+                        // How much the actions are revealed. 0f when hidden, 1f when fully swiped.
+                        val revealProgress = (-swipeState.offset.value / maxOffset).coerceIn(0f, 1f)
+
                         // Collapse the item whenever it is swiped to reveal actions
                         LaunchedEffect(swipeState.offset) {
                             if (swipeState.offset.value != 0f) {
@@ -117,12 +122,14 @@ fun QuizListScreen(
                                 modifier = Modifier
                                     .align(Alignment.CenterEnd)
                                     .height(72.dp)
+                                    .alpha(revealProgress)
                             ) {
                                 IconButton(
                                     onClick = {
                                         scope.launch { swipeState.animateTo(0) }
                                         showRename = true
                                     },
+                                    enabled = swipeState.currentValue == 1,
                                     modifier = Modifier
                                         .background(Color(0xFFFFA500))
                                         .size(actionWidth)
@@ -134,6 +141,7 @@ fun QuizListScreen(
                                         scope.launch { swipeState.animateTo(0) }
                                         showDelete = true
                                     },
+                                    enabled = swipeState.currentValue == 1,
                                     modifier = Modifier
                                         .background(Color.Red)
                                         .size(actionWidth)
@@ -145,7 +153,6 @@ fun QuizListScreen(
                             Column(
                                 modifier = Modifier
                                     .offset { IntOffset(swipeState.offset.value.roundToInt(), 0) }
-                                    .background(Color.White)
                                     .fillMaxWidth()
                                     .padding(vertical = 8.dp)
                             ) {

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/QuizListScreen.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/QuizListScreen.kt
@@ -87,7 +87,14 @@ fun QuizListScreen(
                 Text("Henüz quiziniz yok")
             } else {
                 LazyColumn(modifier = Modifier.weight(1f)) {
-                    itemsIndexed(quizzes) { quizIndex, quiz ->
+                    // Use a stable key so Compose properly disposes state when
+                    // an item is removed. Without this, deleting the last item
+                    // triggers an IndexOutOfBoundsException as the old state
+                    // tries to read a missing index from the list.
+                    itemsIndexed(
+                        items = quizzes,
+                        key = { _, quiz -> quiz.name }
+                    ) { quizIndex, quiz ->
                         var expanded by remember { mutableStateOf(false) }
                         var showRename by remember { mutableStateOf(false) }
                         var showDelete by remember { mutableStateOf(false) }

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/QuizListScreen.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/QuizListScreen.kt
@@ -95,6 +95,13 @@ fun QuizListScreen(
                         val swipeState = rememberSwipeableState(0)
                         val maxOffset = with(LocalDensity.current) { (actionWidth * 2).toPx() }
 
+                        // Collapse the item whenever it is swiped to reveal actions
+                        LaunchedEffect(swipeState.offset) {
+                            if (swipeState.offset.value != 0f) {
+                                expanded = false
+                            }
+                        }
+
                         Box(
                             modifier = Modifier
                                 .fillMaxWidth()
@@ -149,10 +156,12 @@ fun QuizListScreen(
                                         verticalAlignment = Alignment.CenterVertically
                                     ) {
                                         Text(text = quiz.name, modifier = Modifier.weight(1f))
-                                        Icon(
-                                            imageVector = if (expanded) Icons.Default.ArrowDropUp else Icons.Default.ArrowDropDown,
-                                            contentDescription = null
-                                        )
+                                        if (swipeState.offset.value == 0f) {
+                                            Icon(
+                                                imageVector = if (expanded) Icons.Default.ArrowDropUp else Icons.Default.ArrowDropDown,
+                                                contentDescription = null
+                                            )
+                                        }
                                     }
                                     if (expanded) {
                                         Column(

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/viewmodel/QuizViewModel.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/viewmodel/QuizViewModel.kt
@@ -19,6 +19,8 @@ class QuizViewModel : ViewModel() {
     var quizzes: MutableList<UserQuiz> = mutableListOf()
         private set
 
+    private var nextQuizId = 0
+
     /** Index of the quiz currently being viewed */
     private var currentQuizIndex by mutableStateOf(0)
 
@@ -75,7 +77,7 @@ class QuizViewModel : ViewModel() {
     /** Creates a new quiz with the given name and box count */
     fun createQuiz(name: String, count: Int) {
         if (count <= 0) return
-        quizzes.add(UserQuiz(name, MutableList(count) { mutableListOf() }))
+        quizzes.add(UserQuiz(nextQuizId++, name, MutableList(count) { mutableListOf() }))
         currentQuizIndex = quizzes.lastIndex
     }
 
@@ -93,7 +95,7 @@ class QuizViewModel : ViewModel() {
         if (exists) return
         val newBoxes = MutableList(4) { mutableListOf<Question>() }
         newBoxes[0].addAll(quiz.questions.map { it.copy() })
-        quizzes.add(UserQuiz(quiz.name, newBoxes))
+        quizzes.add(UserQuiz(nextQuizId++, quiz.name, newBoxes))
     }
 
     /** Returns the current question in quiz mode */

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/viewmodel/QuizViewModel.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/viewmodel/QuizViewModel.kt
@@ -1,6 +1,7 @@
 package com.cihat.egitim.lottieanimation.viewmodel
 
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
@@ -16,7 +17,7 @@ import kotlin.math.min
 class QuizViewModel : ViewModel() {
 
     /** Quizzes created or imported by the user */
-    var quizzes: MutableList<UserQuiz> = mutableListOf()
+    var quizzes = mutableStateListOf<UserQuiz>()
         private set
 
     private var nextQuizId = 0


### PR DESCRIPTION
## Summary
- update QuizListScreen to hide expand arrow when swiping
- collapse expanded content on swipe

## Testing
- `./gradlew test` *(fails: Unable to download gradle due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6870151ed7f8832daf10096b868c59aa