### PR TITLE
Add folder management screen

### DIFF
--- a/app/src/main/java/com/cihat/egitim/lottieanimation/data/FolderHeading.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/data/FolderHeading.kt
@@ -1,0 +1,11 @@
+package com.cihat.egitim.lottieanimation.data
+
+/**
+ * Represents a heading inside a folder which can contain nested headings.
+ */
+data class FolderHeading(
+    val id: Int,
+    val name: String,
+    val children: MutableList<FolderHeading> = mutableListOf()
+)
+

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/data/UserFolder.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/data/UserFolder.kt
@@ -1,10 +1,14 @@
 package com.cihat.egitim.lottieanimation.data
 
 /**
- * Represents a folder created by the user containing optional sub headings.
+ * Represents a folder created by the user. Each folder can contain
+ * a hierarchy of headings.
  */
+import com.cihat.egitim.lottieanimation.data.FolderHeading
+
 data class UserFolder(
     val id: Int,
     val name: String,
-    val subHeadings: MutableList<String> = mutableListOf()
+    /** Root level headings inside the folder */
+    val headings: MutableList<FolderHeading> = mutableListOf()
 )

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/data/UserFolder.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/data/UserFolder.kt
@@ -1,0 +1,10 @@
+package com.cihat.egitim.lottieanimation.data
+
+/**
+ * Represents a folder created by the user containing optional sub headings.
+ */
+data class UserFolder(
+    val id: Int,
+    val name: String,
+    val subHeadings: MutableList<String> = mutableListOf()
+)

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/data/UserQuiz.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/data/UserQuiz.kt
@@ -8,5 +8,7 @@ data class UserQuiz(
     val name: String,
     val boxes: MutableList<MutableList<Question>>,
     /** Optional sub headings defined by the user */
-    val subHeadings: MutableList<String> = mutableListOf()
+    val subHeadings: MutableList<String> = mutableListOf(),
+    /** Id of the folder this quiz belongs to */
+    val folderId: Int? = null
 )

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/navigation/AppNavHost.kt
@@ -106,13 +106,13 @@ fun AppNavHost(
             )
         }
         composable(Screen.FolderList.route) {
-            FolderListScreen(
+                FolderListScreen(
                 folders = quizViewModel.folders,
                 onRename = { index, name -> quizViewModel.renameFolder(index, name) },
                 onDelete = { index -> quizViewModel.deleteFolder(index) },
-                onRenameSub = { f, s, n -> quizViewModel.renameSubHeading(f, s, n) },
-                onDeleteSub = { f, s -> quizViewModel.deleteSubHeading(f, s) },
-                onAddSub = { f, n -> quizViewModel.addSubHeading(f, n) },
+                onRenameHeading = { f, path, n -> quizViewModel.renameHeading(f, path, n) },
+                onDeleteHeading = { f, path -> quizViewModel.deleteHeading(f, path) },
+                onAddHeading = { f, path, n -> quizViewModel.addHeading(f, path, n) },
                 onCreate = { name, subs -> quizViewModel.createFolder(name, subs) },
                 onLogout = {
                     authViewModel.logout()

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/navigation/AppNavHost.kt
@@ -133,6 +133,7 @@ fun AppNavHost(
         composable(Screen.QuizList.route) {
             QuizListScreen(
                 quizzes = quizViewModel.quizzes,
+                folders = quizViewModel.folders,
                 onQuiz = { quizIdx, boxIdx ->
                     quizViewModel.setCurrentQuiz(quizIdx)
                     if (quizViewModel.startQuiz(boxIdx)) {
@@ -155,8 +156,8 @@ fun AppNavHost(
                 },
                 onRename = { index, name -> quizViewModel.renameQuiz(index, name) },
                 onDelete = { index -> quizViewModel.deleteQuiz(index) },
-                onCreate = { name, count, subs ->
-                    quizViewModel.createQuiz(name, count, subs)
+                onCreate = { name, count, subs, folderId ->
+                    quizViewModel.createQuiz(name, count, subs, folderId)
                 },
                 onLogout = {
                     authViewModel.logout()

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/navigation/AppNavHost.kt
@@ -14,6 +14,7 @@ import com.cihat.egitim.lottieanimation.ui.screens.AddQuestionScreen
 import com.cihat.egitim.lottieanimation.ui.screens.AuthScreen
 import com.cihat.egitim.lottieanimation.ui.screens.BoxListScreen
 import com.cihat.egitim.lottieanimation.ui.screens.HomeFeedScreen
+import com.cihat.egitim.lottieanimation.ui.screens.FolderListScreen
 import com.cihat.egitim.lottieanimation.ui.screens.ProfileScreen
 import com.cihat.egitim.lottieanimation.ui.screens.QuestionListScreen
 import com.cihat.egitim.lottieanimation.ui.screens.QuizListScreen
@@ -27,6 +28,7 @@ sealed class Screen(val route: String) {
     data object Auth : Screen("auth")
     data object Settings : Screen("settings")
     data object QuizList : Screen("quizList")
+    data object FolderList : Screen("folderList")
     data object Profile : Screen("profile")
     data object BoxList : Screen("boxList")
     data object AddQuestion : Screen("addQuestion")
@@ -80,7 +82,7 @@ fun AppNavHost(
                 onPro = {},
                 onAuth = { navController.navigate(Screen.Auth.route) },
                 onSettings = { navController.navigate(Screen.Settings.route) },
-                onFolders = { navController.navigate(Screen.QuizList.route) },
+                onFolders = { navController.navigate(Screen.FolderList.route) },
                 onSupport = {},
                 onRate = {},
                 showBack = canPop,
@@ -88,7 +90,7 @@ fun AppNavHost(
                 onTab = { tab ->
                     when (tab) {
                         BottomTab.PROFILE -> navController.navigate(Screen.Profile.route)
-                        BottomTab.HOME -> navController.navigate(Screen.QuizList.route)
+                        BottomTab.HOME -> navController.navigate(Screen.FolderList.route)
                         BottomTab.EXPLORE -> navController.navigate(Screen.HomeFeed.route)
                     }
                 }
@@ -101,6 +103,28 @@ fun AppNavHost(
                     navController.navigate(Screen.QuizList.route)
                 },
                 onBack = { navController.popBackStack() }
+            )
+        }
+        composable(Screen.FolderList.route) {
+            FolderListScreen(
+                folders = quizViewModel.folders,
+                onRename = { index, name -> quizViewModel.renameFolder(index, name) },
+                onDelete = { index -> quizViewModel.deleteFolder(index) },
+                onCreate = { name, subs -> quizViewModel.createFolder(name, subs) },
+                onLogout = {
+                    authViewModel.logout()
+                    navController.navigate(Screen.Auth.route) {
+                        popUpTo(Screen.FolderList.route) { inclusive = true }
+                    }
+                },
+                onBack = { navController.popBackStack() },
+                onTab = { tab ->
+                    when (tab) {
+                        BottomTab.PROFILE -> navController.navigate(Screen.Profile.route)
+                        BottomTab.HOME -> navController.navigate(Screen.FolderList.route)
+                        BottomTab.EXPLORE -> navController.navigate(Screen.HomeFeed.route)
+                    }
+                }
             )
         }
         composable(Screen.QuizList.route) {
@@ -141,7 +165,7 @@ fun AppNavHost(
                 onTab = { tab ->
                     when (tab) {
                         BottomTab.PROFILE -> navController.navigate(Screen.Profile.route)
-                        BottomTab.HOME -> navController.navigate(Screen.QuizList.route)
+                        BottomTab.HOME -> navController.navigate(Screen.FolderList.route)
                         BottomTab.EXPLORE -> navController.navigate(Screen.HomeFeed.route)
                     }
                 }
@@ -174,7 +198,7 @@ fun AppNavHost(
                 onTab = { tab ->
                     when (tab) {
                         BottomTab.PROFILE -> navController.navigate(Screen.Profile.route)
-                        BottomTab.HOME -> navController.navigate(Screen.QuizList.route)
+                        BottomTab.HOME -> navController.navigate(Screen.FolderList.route)
                         BottomTab.EXPLORE -> navController.navigate(Screen.HomeFeed.route)
                     }
                 }
@@ -208,7 +232,7 @@ fun AppNavHost(
                 onTab = { tab ->
                     when (tab) {
                         BottomTab.PROFILE -> navController.navigate(Screen.Profile.route)
-                        BottomTab.HOME -> navController.navigate(Screen.QuizList.route)
+                        BottomTab.HOME -> navController.navigate(Screen.FolderList.route)
                         BottomTab.EXPLORE -> {}
                     }
                 }

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/navigation/AppNavHost.kt
@@ -90,7 +90,7 @@ fun AppNavHost(
                 onTab = { tab ->
                     when (tab) {
                         BottomTab.PROFILE -> navController.navigate(Screen.Profile.route)
-                        BottomTab.HOME -> navController.navigate(Screen.FolderList.route)
+                        BottomTab.HOME -> navController.navigate(Screen.QuizList.route)
                         BottomTab.EXPLORE -> navController.navigate(Screen.HomeFeed.route)
                     }
                 }
@@ -110,6 +110,9 @@ fun AppNavHost(
                 folders = quizViewModel.folders,
                 onRename = { index, name -> quizViewModel.renameFolder(index, name) },
                 onDelete = { index -> quizViewModel.deleteFolder(index) },
+                onRenameSub = { f, s, n -> quizViewModel.renameSubHeading(f, s, n) },
+                onDeleteSub = { f, s -> quizViewModel.deleteSubHeading(f, s) },
+                onAddSub = { f, n -> quizViewModel.addSubHeading(f, n) },
                 onCreate = { name, subs -> quizViewModel.createFolder(name, subs) },
                 onLogout = {
                     authViewModel.logout()
@@ -121,7 +124,7 @@ fun AppNavHost(
                 onTab = { tab ->
                     when (tab) {
                         BottomTab.PROFILE -> navController.navigate(Screen.Profile.route)
-                        BottomTab.HOME -> navController.navigate(Screen.FolderList.route)
+                        BottomTab.HOME -> navController.navigate(Screen.QuizList.route)
                         BottomTab.EXPLORE -> navController.navigate(Screen.HomeFeed.route)
                     }
                 }
@@ -165,7 +168,7 @@ fun AppNavHost(
                 onTab = { tab ->
                     when (tab) {
                         BottomTab.PROFILE -> navController.navigate(Screen.Profile.route)
-                        BottomTab.HOME -> navController.navigate(Screen.FolderList.route)
+                        BottomTab.HOME -> navController.navigate(Screen.QuizList.route)
                         BottomTab.EXPLORE -> navController.navigate(Screen.HomeFeed.route)
                     }
                 }
@@ -198,7 +201,7 @@ fun AppNavHost(
                 onTab = { tab ->
                     when (tab) {
                         BottomTab.PROFILE -> navController.navigate(Screen.Profile.route)
-                        BottomTab.HOME -> navController.navigate(Screen.FolderList.route)
+                        BottomTab.HOME -> navController.navigate(Screen.QuizList.route)
                         BottomTab.EXPLORE -> navController.navigate(Screen.HomeFeed.route)
                     }
                 }
@@ -232,7 +235,7 @@ fun AppNavHost(
                 onTab = { tab ->
                     when (tab) {
                         BottomTab.PROFILE -> navController.navigate(Screen.Profile.route)
-                        BottomTab.HOME -> navController.navigate(Screen.FolderList.route)
+                        BottomTab.HOME -> navController.navigate(Screen.QuizList.route)
                         BottomTab.EXPLORE -> {}
                     }
                 }

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/FolderListScreen.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/FolderListScreen.kt
@@ -74,7 +74,7 @@ fun FolderListScreen(
         title = "Klasörlerim",
         showBack = true,
         onBack = onBack,
-        bottomTab = BottomTab.HOME,
+        bottomTab = BottomTab.PROFILE,
         onTabSelected = onTab
     ) {
         var showCreate by remember { mutableStateOf(false) }

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/FolderListScreen.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/FolderListScreen.kt
@@ -1,0 +1,300 @@
+package com.cihat.egitim.lottieanimation.ui.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.FractionalThreshold
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.ArrowDropUp
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.rememberSwipeableState
+import androidx.compose.material.swipeable
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExtendedFloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import com.cihat.egitim.lottieanimation.data.UserFolder
+import com.cihat.egitim.lottieanimation.ui.components.AppScaffold
+import com.cihat.egitim.lottieanimation.ui.components.BottomTab
+import kotlinx.coroutines.launch
+import kotlin.math.roundToInt
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+fun FolderListScreen(
+    folders: List<UserFolder>,
+    onRename: (Int, String) -> Unit,
+    onDelete: (Int) -> Unit,
+    onCreate: (String, List<String>) -> Unit,
+    onLogout: () -> Unit,
+    onBack: () -> Unit,
+    onTab: (BottomTab) -> Unit
+) {
+    AppScaffold(
+        title = "Klasörlerim",
+        showBack = true,
+        onBack = onBack,
+        bottomTab = BottomTab.HOME,
+        onTabSelected = onTab
+    ) {
+        var showCreate by remember { mutableStateOf(false) }
+        var createName by remember { mutableStateOf("") }
+        val subHeadings = remember { mutableStateListOf<String>() }
+        var newSub by remember { mutableStateOf("") }
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            if (folders.isEmpty()) {
+                Text("Henüz klasör yok")
+            } else {
+                LazyColumn(modifier = Modifier.weight(1f)) {
+                    itemsIndexed(items = folders, key = { _, f -> f.id }) { index, folder ->
+                        var expanded by remember(folder.id) { mutableStateOf(false) }
+                        var showRename by remember(folder.id) { mutableStateOf(false) }
+                        var showDelete by remember(folder.id) { mutableStateOf(false) }
+                        var newName by remember(folder.id) { mutableStateOf(folder.name) }
+                        val scope = rememberCoroutineScope()
+                        val actionWidth = 72.dp
+                        val swipeState = rememberSwipeableState(0)
+                        val maxOffset = with(LocalDensity.current) { (actionWidth * 2).toPx() }
+                        val revealProgress = (-swipeState.offset.value / maxOffset).coerceIn(0f, 1f)
+                        LaunchedEffect(swipeState.offset) {
+                            if (swipeState.offset.value != 0f) expanded = false
+                        }
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clipToBounds()
+                                .swipeable(
+                                    state = swipeState,
+                                    anchors = mapOf(0f to 0, -maxOffset to 1),
+                                    thresholds = { _, _ -> FractionalThreshold(0.3f) },
+                                    orientation = Orientation.Horizontal
+                                )
+                        ) {
+                            Row(
+                                modifier = Modifier
+                                    .align(Alignment.CenterEnd)
+                                    .height(72.dp)
+                                    .alpha(revealProgress)
+                            ) {
+                                IconButton(
+                                    onClick = {
+                                        scope.launch { swipeState.animateTo(0) }
+                                        showRename = true
+                                    },
+                                    enabled = swipeState.currentValue == 1,
+                                    modifier = Modifier
+                                        .background(Color(0xFFFFA500))
+                                        .size(actionWidth)
+                                ) {
+                                    Icon(Icons.Default.Edit, contentDescription = "Edit", tint = Color.White)
+                                }
+                                IconButton(
+                                    onClick = {
+                                        scope.launch { swipeState.animateTo(0) }
+                                        showDelete = true
+                                    },
+                                    enabled = swipeState.currentValue == 1,
+                                    modifier = Modifier
+                                        .background(Color.Red)
+                                        .size(actionWidth)
+                                ) {
+                                    Icon(Icons.Default.Delete, contentDescription = "Delete", tint = Color.White)
+                                }
+                            }
+
+                            Column(
+                                modifier = Modifier
+                                    .offset { IntOffset(swipeState.offset.value.roundToInt(), 0) }
+                                    .fillMaxWidth()
+                                    .padding(vertical = 8.dp)
+                            ) {
+                                Row(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .height(64.dp)
+                                        .clickable { expanded = !expanded }
+                                        .padding(horizontal = 8.dp),
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    Text(text = folder.name, modifier = Modifier.weight(1f))
+                                    if (swipeState.offset.value == 0f) {
+                                        Icon(
+                                            imageVector = if (expanded) Icons.Default.ArrowDropUp else Icons.Default.ArrowDropDown,
+                                            contentDescription = null
+                                        )
+                                    }
+                                }
+                                if (expanded) {
+                                    Column(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .padding(start = 32.dp, top = 4.dp)
+                                    ) {
+                                        folder.subHeadings.forEach { sub ->
+                                            Text(text = sub)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        if (showRename) {
+                            AlertDialog(
+                                onDismissRequest = { showRename = false },
+                                confirmButton = {
+                                    TextButton(onClick = {
+                                        onRename(index, newName)
+                                        showRename = false
+                                    }) { Text("Save") }
+                                },
+                                dismissButton = {
+                                    TextButton(onClick = { showRename = false }) { Text("Cancel") }
+                                },
+                                title = { Text("Edit Folder") },
+                                text = {
+                                    OutlinedTextField(
+                                        value = newName,
+                                        onValueChange = { newName = it },
+                                        label = { Text("Name") }
+                                    )
+                                }
+                            )
+                        }
+
+                        if (showDelete) {
+                            AlertDialog(
+                                onDismissRequest = { showDelete = false },
+                                confirmButton = {
+                                    TextButton(onClick = {
+                                        onDelete(index)
+                                        showDelete = false
+                                    }) { Text("Evet") }
+                                },
+                                dismissButton = {
+                                    TextButton(onClick = { showDelete = false }) { Text("Hayır") }
+                                },
+                                text = { Text("Silmek istediğinize emin misiniz?") }
+                            )
+                        }
+                        Spacer(modifier = Modifier.height(8.dp))
+                    }
+                }
+                Button(onClick = onLogout, modifier = Modifier.padding(top = 8.dp)) {
+                    Text("Logout")
+                }
+            }
+            ExtendedFloatingActionButton(
+                onClick = { showCreate = true },
+                icon = { Icon(Icons.Default.Add, contentDescription = "Add") },
+                text = { Text("Klasör Oluştur") },
+                modifier = Modifier
+                    .align(Alignment.End)
+                    .padding(16.dp),
+                containerColor = MaterialTheme.colorScheme.primary,
+                contentColor = MaterialTheme.colorScheme.onPrimary
+            )
+        }
+
+        if (showCreate) {
+            AlertDialog(
+                onDismissRequest = { showCreate = false },
+                confirmButton = {
+                    TextButton(onClick = {
+                        onCreate(createName, subHeadings.toList())
+                        showCreate = false
+                        createName = ""
+                        subHeadings.clear()
+                    }) { Text("Oluştur") }
+                },
+                dismissButton = {
+                    TextButton(onClick = { showCreate = false }) { Text("İptal") }
+                },
+                title = { Text("Klasör Oluştur") },
+                text = {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        OutlinedTextField(
+                            value = createName,
+                            onValueChange = { createName = it },
+                            label = { Text("Ad") },
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                        subHeadings.forEachIndexed { index, text ->
+                            OutlinedTextField(
+                                value = text,
+                                onValueChange = { subHeadings[index] = it },
+                                label = { Text("Alt Başlık ${index + 1}") },
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(top = 4.dp)
+                            )
+                        }
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(top = 8.dp)
+                        ) {
+                            OutlinedTextField(
+                                value = newSub,
+                                onValueChange = { newSub = it },
+                                label = { Text("Alt Başlık Ekle") },
+                                modifier = Modifier.weight(1f)
+                            )
+                            IconButton(onClick = {
+                                if (newSub.isNotBlank()) {
+                                    subHeadings.add(newSub)
+                                    newSub = ""
+                                }
+                            }) {
+                                Icon(Icons.Default.Add, contentDescription = "Add sub")
+                            }
+                        }
+                    }
+                }
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/FolderListScreen.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/FolderListScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.ExperimentalMaterialApi

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/QuizListScreen.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/QuizListScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.FloatingActionButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
@@ -61,6 +62,7 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.material.icons.filled.Add
 import com.cihat.egitim.lottieanimation.data.UserQuiz
+import com.cihat.egitim.lottieanimation.data.UserFolder
 import com.cihat.egitim.lottieanimation.ui.components.AppScaffold
 import com.cihat.egitim.lottieanimation.ui.components.BottomTab
 import kotlinx.coroutines.launch
@@ -70,12 +72,13 @@ import kotlin.math.roundToInt
 @Composable
 fun QuizListScreen(
     quizzes: List<UserQuiz>,
+    folders: List<UserFolder>,
     onQuiz: (Int, Int) -> Unit,
     onView: (Int, Int) -> Unit,
     onAdd: (Int) -> Unit,
     onRename: (Int, String) -> Unit,
     onDelete: (Int) -> Unit,
-    onCreate: (String, Int, List<String>) -> Unit,
+    onCreate: (String, Int, List<String>, Int?) -> Unit,
     onLogout: () -> Unit,
     onBack: () -> Unit,
     onTab: (BottomTab) -> Unit
@@ -88,6 +91,7 @@ fun QuizListScreen(
         onTabSelected = onTab
     ) {
         var showCreate by remember { mutableStateOf(false) }
+        var showFolderSelect by remember { mutableStateOf(false) }
         var createName by remember { mutableStateOf("") }
         var createCount by remember { mutableFloatStateOf(4f) }
         val subHeadings = remember { mutableStateListOf<String>() }
@@ -292,7 +296,7 @@ fun QuizListScreen(
             ExtendedFloatingActionButton(
                 onClick = { showCreate = true },
                 icon = { Icon(Icons.Default.Add, contentDescription = "Add") },
-                text = { Text("Klasör Oluştur") },
+                text = { Text("Quiz Ekle") },
                 modifier = Modifier
                     .align(Alignment.BottomEnd)
                     .padding(16.dp)
@@ -310,17 +314,14 @@ fun QuizListScreen(
                 onDismissRequest = { showCreate = false },
                 confirmButton = {
                     TextButton(onClick = {
-                        onCreate(createName, createCount.toInt(), subHeadings.toList())
                         showCreate = false
-                        createName = ""
-                        createCount = 4f
-                        subHeadings.clear()
-                    }) { Text("Oluştur") }
+                        showFolderSelect = true
+                    }) { Text("İleri") }
                 },
                 dismissButton = {
                     TextButton(onClick = { showCreate = false }) { Text("İptal") }
                 },
-                title = { Text("Klasör Oluştur") },
+                title = { Text("Quiz Oluştur") },
                 text = {
                     Column(horizontalAlignment = Alignment.CenterHorizontally) {
                         OutlinedTextField(
@@ -365,6 +366,50 @@ fun QuizListScreen(
                                 }
                             }) {
                                 Icon(Icons.Default.Add, contentDescription = "Add sub")
+                            }
+                        }
+                    }
+                }
+            )
+        }
+
+        if (showFolderSelect) {
+            var selected by remember { mutableStateOf(folders.firstOrNull()?.id) }
+            AlertDialog(
+                onDismissRequest = { showFolderSelect = false },
+                confirmButton = {
+                    TextButton(onClick = {
+                        onCreate(createName, createCount.toInt(), subHeadings.toList(), selected)
+                        showFolderSelect = false
+                        createName = ""
+                        createCount = 4f
+                        subHeadings.clear()
+                        newSub = ""
+                    }) { Text("Oluştur") }
+                },
+                dismissButton = {
+                    TextButton(onClick = { showFolderSelect = false }) { Text("İptal") }
+                },
+                title = { Text("Klasör Seç") },
+                text = {
+                    if (folders.isEmpty()) {
+                        Text("Önce klasör oluşturun")
+                    } else {
+                        Column {
+                            folders.forEach { folder ->
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .clickable { selected = folder.id }
+                                        .padding(4.dp)
+                                ) {
+                                    RadioButton(
+                                        selected = selected == folder.id,
+                                        onClick = { selected = folder.id }
+                                    )
+                                    Text(folder.name, modifier = Modifier.padding(start = 8.dp))
+                                }
                             }
                         }
                     }

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/viewmodel/QuizViewModel.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/viewmodel/QuizViewModel.kt
@@ -137,7 +137,12 @@ class QuizViewModel : ViewModel() {
     }
 
     /** Creates a new quiz with the given name, box count and optional sub headings */
-    fun createQuiz(name: String, count: Int, subHeadings: List<String> = emptyList()) {
+    fun createQuiz(
+        name: String,
+        count: Int,
+        subHeadings: List<String> = emptyList(),
+        folderId: Int? = null
+    ) {
         if (count <= 0) return
         // Prevent creating multiple quizzes with the same name
         val exists = quizzes.any { it.name == name }
@@ -147,7 +152,8 @@ class QuizViewModel : ViewModel() {
                 id = nextQuizId++,
                 name = name,
                 boxes = MutableList(count) { mutableListOf() },
-                subHeadings = subHeadings.toMutableList()
+                subHeadings = subHeadings.toMutableList(),
+                folderId = folderId
             )
         )
         currentQuizIndex = quizzes.lastIndex

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/viewmodel/QuizViewModel.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/viewmodel/QuizViewModel.kt
@@ -95,6 +95,31 @@ class QuizViewModel : ViewModel() {
         )
     }
 
+    /** Renames a sub heading of the folder */
+    fun renameSubHeading(folderIndex: Int, subIndex: Int, newName: String) {
+        val folder = folders.getOrNull(folderIndex) ?: return
+        if (newName.isBlank() || subIndex !in folder.subHeadings.indices) return
+        folder.subHeadings[subIndex] = newName
+        // Trigger recomposition
+        folders[folderIndex] = folder.copy()
+    }
+
+    /** Deletes the sub heading at the given index */
+    fun deleteSubHeading(folderIndex: Int, subIndex: Int) {
+        val folder = folders.getOrNull(folderIndex) ?: return
+        if (subIndex !in folder.subHeadings.indices) return
+        folder.subHeadings.removeAt(subIndex)
+        folders[folderIndex] = folder.copy()
+    }
+
+    /** Adds a new sub heading to the folder */
+    fun addSubHeading(folderIndex: Int, name: String) {
+        val folder = folders.getOrNull(folderIndex) ?: return
+        if (name.isBlank()) return
+        folder.subHeadings.add(name)
+        folders[folderIndex] = folder.copy()
+    }
+
     /** Renames the quiz at the given index */
     fun renameQuiz(index: Int, newName: String) {
         val quiz = quizzes.getOrNull(index) ?: return

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/viewmodel/QuizViewModel.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/viewmodel/QuizViewModel.kt
@@ -147,8 +147,14 @@ class QuizViewModel : ViewModel() {
     fun addHeading(folderIndex: Int, path: List<Int>, name: String) {
         if (name.isBlank()) return
         val folder = folders.getOrNull(folderIndex) ?: return
-        val parent = if (path.isEmpty()) folder.headings else getHeadingAt(folder.headings, path) ?: return
-        parent.children.add(FolderHeading(id = nextHeadingId++, name = name))
+        val targetList: MutableList<FolderHeading> =
+            if (path.isEmpty()) {
+                folder.headings
+            } else {
+                getHeadingAt(folder.headings, path)?.children ?: return
+            }
+
+        targetList.add(FolderHeading(id = nextHeadingId++, name = name))
         folders[folderIndex] = folder.copy()
     }
 

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/viewmodel/QuizViewModel.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/viewmodel/QuizViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.ViewModel
 import com.cihat.egitim.lottieanimation.data.Question
 import com.cihat.egitim.lottieanimation.data.PublicQuiz
 import com.cihat.egitim.lottieanimation.data.UserQuiz
+import com.cihat.egitim.lottieanimation.data.UserFolder
 import kotlin.math.min
 
 /**
@@ -15,6 +16,12 @@ import kotlin.math.min
  * questions. Also manages quiz progress state.
  */
 class QuizViewModel : ViewModel() {
+
+    /** Folders created by the user */
+    var folders = mutableStateListOf<UserFolder>()
+        private set
+
+    private var nextFolderId = 0
 
     /** Quizzes created or imported by the user */
     var quizzes = mutableStateListOf<UserQuiz>()
@@ -58,6 +65,35 @@ class QuizViewModel : ViewModel() {
 
     var isAnswerVisible by mutableStateOf(false)
         private set
+
+    /** Renames the folder at the given index */
+    fun renameFolder(index: Int, newName: String) {
+        val folder = folders.getOrNull(index) ?: return
+        if (newName.isNotBlank()) {
+            folders[index] = folder.copy(name = newName)
+        }
+    }
+
+    /** Deletes the folder at the given index */
+    fun deleteFolder(index: Int) {
+        if (index in folders.indices) {
+            folders.removeAt(index)
+        }
+    }
+
+    /** Creates a new folder with optional sub headings */
+    fun createFolder(name: String, subHeadings: List<String> = emptyList()) {
+        if (name.isBlank()) return
+        val exists = folders.any { it.name == name }
+        if (exists) return
+        folders.add(
+            UserFolder(
+                id = nextFolderId++,
+                name = name,
+                subHeadings = subHeadings.toMutableList()
+            )
+        )
+    }
 
     /** Renames the quiz at the given index */
     fun renameQuiz(index: Int, newName: String) {


### PR DESCRIPTION
## Summary
- introduce `UserFolder` data model
- extend `QuizViewModel` with folder operations
- add new `FolderListScreen` for listing folders
- route navigation to the folder screen from profile
- update navigation to include new `FolderList` route

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687110c606d0832db7e657b9f0065989