### PR TITLE
Fix nested heading edit/delete

### DIFF
--- a/app/src/main/java/com/cihat/egitim/lottieanimation/viewmodel/QuizViewModel.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/viewmodel/QuizViewModel.kt
@@ -83,8 +83,9 @@ class QuizViewModel : ViewModel() {
     private fun getHeadingParent(list: MutableList<FolderHeading>, path: List<Int>): MutableList<FolderHeading>? {
         if (path.isEmpty()) return list
         var currentList = list
-        for (i in 0 until path.size - 1) {
-            val h = currentList.getOrNull(i) ?: return null
+        for (level in 0 until path.size - 1) {
+            val index = path[level]
+            val h = currentList.getOrNull(index) ?: return null
             currentList = h.children
         }
         return currentList


### PR DESCRIPTION
## Summary
- fix heading parent traversal so subheadings can be edited and deleted properly

## Testing
- `./gradlew test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68715204c054832da88e6b642dd43582