### PR TITLE
Enhanced quiz creation flow

### DIFF
--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/navigation/AppNavHost.kt
@@ -156,8 +156,11 @@ fun AppNavHost(
                 },
                 onRename = { index, name -> quizViewModel.renameQuiz(index, name) },
                 onDelete = { index -> quizViewModel.deleteQuiz(index) },
-                onCreate = { name, count, subs, folderId ->
-                    quizViewModel.createQuiz(name, count, subs, folderId)
+                onCreate = { name, count, folderId ->
+                    quizViewModel.createQuiz(name, count, emptyList(), folderId)
+                },
+                onCreateWithQuestion = { name, count, folderId, topic, sub, q, a ->
+                    quizViewModel.createQuizWithQuestion(name, count, folderId, topic, sub, q, a)
                 },
                 onLogout = {
                     authViewModel.logout()

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/navigation/AppNavHost.kt
@@ -165,6 +165,7 @@ fun AppNavHost(
                         popUpTo(Screen.QuizList.route) { inclusive = true }
                     }
                 },
+                onFolders = { navController.navigate(Screen.FolderList.route) },
                 onBack = { navController.popBackStack() },
                 onTab = { tab ->
                     when (tab) {
@@ -211,6 +212,7 @@ fun AppNavHost(
         composable(Screen.AddQuestion.route) {
             AddQuestionScreen(
                 boxCount = quizViewModel.boxes.size,
+                headings = quizViewModel.currentQuizFolderHeadings,
                 onAdd = { q, a, topic, sub, box ->
                     quizViewModel.addQuestion(q, a, topic, sub, box)
                 },

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/AddQuestionScreen.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/AddQuestionScreen.kt
@@ -17,15 +17,14 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material3.Button
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.ExperimentalMaterialApi
-import androidx.compose.material3.ExposedDropdownMenu
-import androidx.compose.material3.menuAnchor
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -39,7 +38,7 @@ import androidx.compose.ui.unit.dp
 import com.cihat.egitim.lottieanimation.ui.components.AppScaffold
 import com.cihat.egitim.lottieanimation.data.FolderHeading
 
-@OptIn(ExperimentalMaterialApi::class)
+@OptIn(ExperimentalMaterialApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun AddQuestionScreen(
     boxCount: Int,

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/QuizListScreen.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/QuizListScreen.kt
@@ -43,8 +43,6 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.ExposedDropdownMenu
-import androidx.compose.material3.menuAnchor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.shape.CircleShape
@@ -68,6 +66,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.ui.res.painterResource
 import androidx.compose.foundation.Image
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.ui.draw.clip
 import com.cihat.egitim.lottieanimation.data.UserQuiz
 import com.cihat.egitim.lottieanimation.data.UserFolder
 import com.cihat.egitim.lottieanimation.ui.components.AppScaffold
@@ -75,7 +75,7 @@ import com.cihat.egitim.lottieanimation.ui.components.BottomTab
 import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
 
-@OptIn(ExperimentalMaterialApi::class, androidx.compose.material3.ExperimentalMaterialApi::class)
+@OptIn(ExperimentalMaterialApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun QuizListScreen(
     quizzes: List<UserQuiz>,

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/QuizListScreen.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/QuizListScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -61,6 +62,8 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.ui.res.painterResource
+import androidx.compose.foundation.Image
 import com.cihat.egitim.lottieanimation.data.UserQuiz
 import com.cihat.egitim.lottieanimation.data.UserFolder
 import com.cihat.egitim.lottieanimation.ui.components.AppScaffold
@@ -80,6 +83,7 @@ fun QuizListScreen(
     onDelete: (Int) -> Unit,
     onCreate: (String, Int, List<String>, Int?) -> Unit,
     onLogout: () -> Unit,
+    onFolders: () -> Unit,
     onBack: () -> Unit,
     onTab: (BottomTab) -> Unit
 ) {
@@ -92,6 +96,7 @@ fun QuizListScreen(
     ) {
         var showCreate by remember { mutableStateOf(false) }
         var showFolderSelect by remember { mutableStateOf(false) }
+        var showWarning by remember { mutableStateOf(false) }
         var createName by remember { mutableStateOf("") }
         var createCount by remember { mutableFloatStateOf(4f) }
         val subHeadings = remember { mutableStateListOf<String>() }
@@ -294,7 +299,13 @@ fun QuizListScreen(
                 }
             }
             ExtendedFloatingActionButton(
-                onClick = { showCreate = true },
+                onClick = {
+                    if (folders.isEmpty()) {
+                        showWarning = true
+                    } else {
+                        showCreate = true
+                    }
+                },
                 icon = { Icon(Icons.Default.Add, contentDescription = "Add") },
                 text = { Text("Quiz Ekle") },
                 modifier = Modifier
@@ -414,6 +425,32 @@ fun QuizListScreen(
                         }
                     }
                 }
+            )
+        }
+
+        if (showWarning) {
+            AlertDialog(
+                onDismissRequest = { showWarning = false },
+                confirmButton = {
+                    TextButton(onClick = {
+                        showWarning = false
+                        onFolders()
+                    }) { Text("Klasör Oluştur") }
+                },
+                dismissButton = {
+                    TextButton(onClick = { showWarning = false }) { Text("Kapat") }
+                },
+                icon = {
+                    androidx.compose.foundation.Image(
+                        painter = androidx.compose.ui.res.painterResource(id = com.cihat.egitim.lottieanimation.R.drawable.knowledge_logo),
+                        contentDescription = null,
+                        modifier = Modifier
+                            .size(64.dp)
+                            .clip(CircleShape)
+                    )
+                },
+                title = { Text("Uyarı") },
+                text = { Text("Quiz oluşturmak için klasör oluşturunuz.") }
             )
         }
         }

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/viewmodel/QuizViewModel.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/viewmodel/QuizViewModel.kt
@@ -204,6 +204,22 @@ class QuizViewModel : ViewModel() {
         currentQuizIndex = quizzes.lastIndex
     }
 
+    /**
+     * Creates a quiz and immediately adds an initial question to the first box.
+     */
+    fun createQuizWithQuestion(
+        name: String,
+        count: Int,
+        folderId: Int?,
+        topic: String,
+        subtopic: String,
+        question: String,
+        answer: String
+    ) {
+        createQuiz(name, count, emptyList(), folderId)
+        addQuestion(question, answer, topic, subtopic, 0)
+    }
+
     /** Changes the active quiz */
     fun setCurrentQuiz(index: Int) {
         currentQuizIndex = index.coerceIn(0, quizzes.lastIndex)

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/viewmodel/QuizViewModel.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/viewmodel/QuizViewModel.kt
@@ -42,6 +42,13 @@ class QuizViewModel : ViewModel() {
     val currentQuizName: String
         get() = quizzes.getOrNull(currentQuizIndex)?.name ?: ""
 
+    /** Headings of the folder the current quiz belongs to */
+    val currentQuizFolderHeadings: List<FolderHeading>
+        get() {
+            val folderId = quizzes.getOrNull(currentQuizIndex)?.folderId
+            return folders.find { it.id == folderId }?.headings ?: emptyList()
+        }
+
     /** Sample public quizzes that could come from a backend in a real app */
     val publicQuizzes: List<PublicQuiz> = listOf(
         PublicQuiz(


### PR DESCRIPTION
## Summary
- expose `currentQuizFolderHeadings` in the view model
- rework AddQuestionScreen to pick headings from the quiz folder
- show warning dialog if there is no folder when creating a quiz
- support navigation to folder list from quiz list
- pass folder headings to AddQuestionScreen

## Testing
- `./gradlew test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687157342af4832d864d0bf821f69ca0