### PR TITLE
Add quick question addition via swipe

### DIFF
--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/navigation/AppNavHost.kt
@@ -162,6 +162,10 @@ fun AppNavHost(
                 onCreateWithQuestion = { name, count, folderId, topic, sub, q, a ->
                     quizViewModel.createQuizWithQuestion(name, count, folderId, topic, sub, q, a)
                 },
+                onQuickAdd = { qIdx, topic, sub, q, a ->
+                    quizViewModel.setCurrentQuiz(qIdx)
+                    quizViewModel.addQuestion(q, a, topic, sub, 0)
+                },
                 onLogout = {
                     authViewModel.logout()
                     navController.navigate(Screen.Auth.route) {


### PR DESCRIPTION
## Summary
- allow swiping right on quiz rows to show an `Add` action
- open a dialog for adding a question to the quiz's first box
- wire navigation to handle the new callback

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871618ec704832d8ab2829dad3fca74