### PR TITLE
Fix quiz list drag reorder

### DIFF
--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/QuizListScreen.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/QuizListScreen.kt
@@ -170,18 +170,29 @@ fun QuizListScreen(
                             .offset { IntOffset(0, if (isDragging) dragOffset.roundToInt() else 0) }
                             .pointerInput(quiz.id) {
                                 detectDragGesturesAfterLongPress(
-                                    onDragStart = { draggingIndex = quizIndex; dragOffset = 0f },
-                                    onDragCancel = { dragOffset = 0f; draggingIndex = -1 },
+                                    onDragStart = {
+                                        draggingIndex = quizIndex
+                                        dragOffset = 0f
+                                    },
+                                    onDragCancel = {
+                                        dragOffset = 0f
+                                        draggingIndex = -1
+                                    },
                                     onDragEnd = {
-                                        val newIndex = (draggingIndex + (dragOffset / itemHeightPx).roundToInt())
-                                            .coerceIn(0, quizzes.lastIndex)
-                                        if (newIndex != draggingIndex) onMoveQuiz(draggingIndex, newIndex)
                                         dragOffset = 0f
                                         draggingIndex = -1
                                     },
                                     onDrag = { change, dragAmount ->
                                         change.consume()
                                         dragOffset += dragAmount.y
+                                        val from = draggingIndex
+                                        val potentialIndex = (from + (dragOffset / itemHeightPx).roundToInt())
+                                            .coerceIn(0, quizzes.lastIndex)
+                                        if (potentialIndex != from) {
+                                            onMoveQuiz(from, potentialIndex)
+                                            draggingIndex = potentialIndex
+                                            dragOffset -= (potentialIndex - from) * itemHeightPx
+                                        }
                                     }
                                 )
                             }

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/QuizListScreen.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/QuizListScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.lazy.animateItemPlacement
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.FractionalThreshold
 import androidx.compose.material.icons.Icons
@@ -115,6 +116,7 @@ fun QuizListScreen(
         var answerText by remember { mutableStateOf("") }
 
         val listState = rememberLazyListState()
+        var draggingQuizId by remember { mutableStateOf<Int?>(null) }
         var draggingIndex by remember { mutableIntStateOf(-1) }
         var dragOffset by remember { mutableFloatStateOf(0f) }
         val itemHeightPx = with(LocalDensity.current) { 72.dp.toPx() }
@@ -165,22 +167,25 @@ fun QuizListScreen(
                             }
                         }
 
-                        val isDragging = draggingIndex == quizIndex
+                        val isDragging = draggingQuizId == quiz.id
                         val dragModifier = Modifier
                             .offset { IntOffset(0, if (isDragging) dragOffset.roundToInt() else 0) }
                             .pointerInput(quiz.id) {
                                 detectDragGesturesAfterLongPress(
                                     onDragStart = {
-                                        draggingIndex = quizIndex
+                                        draggingQuizId = quiz.id
+                                        draggingIndex = quizzes.indexOfFirst { it.id == quiz.id }
                                         dragOffset = 0f
                                     },
                                     onDragCancel = {
                                         dragOffset = 0f
                                         draggingIndex = -1
+                                        draggingQuizId = null
                                     },
                                     onDragEnd = {
                                         dragOffset = 0f
                                         draggingIndex = -1
+                                        draggingQuizId = null
                                     },
                                     onDrag = { change, dragAmount ->
                                         change.consume()
@@ -207,7 +212,7 @@ fun QuizListScreen(
                                     thresholds = { _, _ -> FractionalThreshold(0.3f) },
                                     orientation = Orientation.Horizontal
                                 )
-                                .animateItem()
+                                .animateItemPlacement()
                         ) {
                             Row(
                                 modifier = Modifier

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/QuizListScreen.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/QuizListScreen.kt
@@ -170,12 +170,12 @@ fun QuizListScreen(
                             .offset { IntOffset(0, if (isDragging) dragOffset.roundToInt() else 0) }
                             .pointerInput(quiz.id) {
                                 detectDragGesturesAfterLongPress(
-                                    onDragStart = { draggingIndex = quizIndex },
+                                    onDragStart = { draggingIndex = quizIndex; dragOffset = 0f },
                                     onDragCancel = { dragOffset = 0f; draggingIndex = -1 },
                                     onDragEnd = {
-                                        val newIndex = (quizIndex + (dragOffset / itemHeightPx).roundToInt())
+                                        val newIndex = (draggingIndex + (dragOffset / itemHeightPx).roundToInt())
                                             .coerceIn(0, quizzes.lastIndex)
-                                        if (newIndex != quizIndex) onMoveQuiz(quizIndex, newIndex)
+                                        if (newIndex != draggingIndex) onMoveQuiz(draggingIndex, newIndex)
                                         dragOffset = 0f
                                         draggingIndex = -1
                                     },

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/QuizListScreen.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/QuizListScreen.kt
@@ -17,12 +17,10 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.lazy.animateItemPlacement
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.FractionalThreshold
 import androidx.compose.material.icons.Icons
@@ -36,10 +34,8 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.ExtendedFloatingActionButton
-import androidx.compose.material3.FloatingActionButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.RadioButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
@@ -68,8 +64,6 @@ import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.res.painterResource
-import androidx.compose.foundation.Image
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.input.pointer.pointerInput
@@ -212,7 +206,7 @@ fun QuizListScreen(
                                     thresholds = { _, _ -> FractionalThreshold(0.3f) },
                                     orientation = Orientation.Horizontal
                                 )
-                                .animateItemPlacement()
+                                .animateItem()
                         ) {
                             Row(
                                 modifier = Modifier

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/viewmodel/QuizViewModel.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/viewmodel/QuizViewModel.kt
@@ -234,8 +234,7 @@ class QuizViewModel : ViewModel() {
     fun moveQuiz(fromIndex: Int, toIndex: Int) {
         if (fromIndex !in quizzes.indices || toIndex !in quizzes.indices) return
         val quiz = quizzes.removeAt(fromIndex)
-        val destination = if (toIndex > fromIndex) toIndex - 1 else toIndex
-        quizzes.add(destination, quiz)
+        quizzes.add(toIndex, quiz)
     }
 
     /** Creates a new quiz with the given name, box count and optional sub headings */


### PR DESCRIPTION
## Summary
- ensure long press drag moves selected quiz
- simplify quiz move logic

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872b3e4904c832daa4ea4a1c708de89