### PR TITLE
Add question editing and deletion

### DIFF
--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/navigation/AppNavHost.kt
@@ -269,9 +269,10 @@ fun AppNavHost(
             arguments = listOf(navArgument(Screen.QuestionList.boxArg) { type = NavType.IntType })
         ) { backStackEntry ->
             val index = backStackEntry.arguments?.getInt(Screen.QuestionList.boxArg) ?: 0
-            val questions = quizViewModel.boxes.getOrNull(index).orEmpty()
             QuestionListScreen(
-                questions = questions,
+                questions = quizViewModel.boxes.getOrNull(index).orEmpty(),
+                onEdit = { qIdx, q -> quizViewModel.editQuestion(index, qIdx, q) },
+                onDelete = { qIdx -> quizViewModel.deleteQuestion(index, qIdx) },
                 onBack = { navController.popBackStack() }
             )
         }

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/navigation/AppNavHost.kt
@@ -220,7 +220,7 @@ fun AppNavHost(
         composable(Screen.AddQuestion.route) {
             AddQuestionScreen(
                 boxCount = quizViewModel.boxes.size,
-                headings = quizViewModel.currentQuizFolderHeadings,
+                headings = quizViewModel.currentQuizHeadingOptions,
                 onAdd = { q, a, topic, sub, box ->
                     quizViewModel.addQuestion(q, a, topic, sub, box)
                 },
@@ -271,6 +271,7 @@ fun AppNavHost(
             val index = backStackEntry.arguments?.getInt(Screen.QuestionList.boxArg) ?: 0
             QuestionListScreen(
                 questions = quizViewModel.boxes.getOrNull(index).orEmpty(),
+                headings = quizViewModel.currentQuizHeadingOptions,
                 onEdit = { qIdx, q -> quizViewModel.editQuestion(index, qIdx, q) },
                 onDelete = { qIdx -> quizViewModel.deleteQuestion(index, qIdx) },
                 onBack = { navController.popBackStack() }

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/QuestionListScreen.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/QuestionListScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.FractionalThreshold
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
@@ -27,6 +28,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -46,6 +48,7 @@ import com.cihat.egitim.lottieanimation.data.Question
 import com.cihat.egitim.lottieanimation.data.FolderHeading
 import com.cihat.egitim.lottieanimation.ui.components.AppScaffold
 import kotlinx.coroutines.launch
+import kotlin.math.roundToInt
 
 /** Finds heading index path for the provided names */
 private fun findPath(names: List<String>, headings: List<FolderHeading>): List<Int> {
@@ -60,6 +63,7 @@ private fun findPath(names: List<String>, headings: List<FolderHeading>): List<I
     return path
 }
 
+@OptIn(ExperimentalMaterialApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun QuestionListScreen(
     questions: List<Question>,

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/QuestionListScreen.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/QuestionListScreen.kt
@@ -1,21 +1,52 @@
 package com.cihat.egitim.lottieanimation.ui.screens
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.FractionalThreshold
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.rememberSwipeableState
+import androidx.compose.material.swipeable
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.cihat.egitim.lottieanimation.data.Question
 import com.cihat.egitim.lottieanimation.ui.components.AppScaffold
+import kotlinx.coroutines.launch
 
 @Composable
 fun QuestionListScreen(
     questions: List<Question>,
+    onEdit: (Int, Question) -> Unit,
+    onDelete: (Int) -> Unit,
     onBack: () -> Unit
 ) {
     AppScaffold(
@@ -30,13 +61,122 @@ fun QuestionListScreen(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             LazyColumn(modifier = Modifier.weight(1f)) {
-                items(questions) { q ->
-                    Column(modifier = Modifier.padding(vertical = 8.dp)) {
-                        Text(text = q.text)
-                        Text(text = q.answer)
+                itemsIndexed(questions) { index, q ->
+                    var showEdit by remember(q) { mutableStateOf(false) }
+                    var newQuestion by remember(q) { mutableStateOf(q.text) }
+                    var newAnswer by remember(q) { mutableStateOf(q.answer) }
+                    var newTopic by remember(q) { mutableStateOf(q.topic) }
+                    var newSub by remember(q) { mutableStateOf(q.subtopic) }
+
+                    val swipeState = rememberSwipeableState(0)
+                    val actionWidth = 72.dp
+                    val maxOffset = with(LocalDensity.current) { (actionWidth * 2).toPx() }
+                    val reveal = (-swipeState.offset.value / maxOffset).coerceIn(0f, 1f)
+                    val scope = rememberCoroutineScope()
+
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .swipeable(
+                                state = swipeState,
+                                anchors = mapOf(0f to 0, -maxOffset to 1),
+                                thresholds = { _, _ -> FractionalThreshold(0.3f) },
+                                orientation = Orientation.Horizontal
+                            )
+                    ) {
+                        Row(
+                            modifier = Modifier
+                                .align(Alignment.CenterEnd)
+                                .height(72.dp)
+                                .alpha(reveal)
+                        ) {
+                            IconButton(
+                                onClick = {
+                                    scope.launch { swipeState.animateTo(0) }
+                                    showEdit = true
+                                },
+                                enabled = swipeState.currentValue == 1,
+                                modifier = Modifier
+                                    .background(Color(0xFFFFA500))
+                                    .height(72.dp)
+                                    .padding(horizontal = 12.dp)
+                            ) {
+                                Icon(Icons.Default.Edit, contentDescription = "Edit", tint = Color.White)
+                            }
+                            IconButton(
+                                onClick = {
+                                    scope.launch { swipeState.animateTo(0) }
+                                    onDelete(index)
+                                },
+                                enabled = swipeState.currentValue == 1,
+                                modifier = Modifier
+                                    .background(Color.Red)
+                                    .height(72.dp)
+                                    .padding(horizontal = 12.dp)
+                            ) {
+                                Icon(Icons.Default.Delete, contentDescription = "Delete", tint = Color.White)
+                            }
+                        }
+
+                        Column(
+                            modifier = Modifier
+                                .offset { IntOffset(swipeState.offset.value.roundToInt(), 0) }
+                                .fillMaxWidth()
+                                .padding(vertical = 8.dp)
+                        ) {
+                            Text(text = q.topic)
+                            Text(text = q.subtopic)
+                            Text(text = q.text)
+                            Text(text = q.answer)
+                        }
+                    }
+
+                    if (showEdit) {
+                        AlertDialog(
+                            onDismissRequest = { showEdit = false },
+                            confirmButton = {
+                                TextButton(onClick = {
+                                    onEdit(index, Question(newQuestion, newAnswer, newTopic, newSub))
+                                    showEdit = false
+                                }) { Text("Save") }
+                            },
+                            dismissButton = {
+                                TextButton(onClick = { showEdit = false }) { Text("Cancel") }
+                            },
+                            title = { Text("Edit Question") },
+                            text = {
+                                Column {
+                                    OutlinedTextField(
+                                        value = newTopic,
+                                        onValueChange = { newTopic = it },
+                                        label = { Text("Topic") },
+                                        modifier = Modifier.fillMaxWidth()
+                                    )
+                                    OutlinedTextField(
+                                        value = newSub,
+                                        onValueChange = { newSub = it },
+                                        label = { Text("Subtopic") },
+                                        modifier = Modifier.fillMaxWidth()
+                                    )
+                                    OutlinedTextField(
+                                        value = newQuestion,
+                                        onValueChange = { newQuestion = it },
+                                        label = { Text("Question") },
+                                        modifier = Modifier.fillMaxWidth()
+                                    )
+                                    OutlinedTextField(
+                                        value = newAnswer,
+                                        onValueChange = { newAnswer = it },
+                                        label = { Text("Answer") },
+                                        modifier = Modifier.fillMaxWidth()
+                                    )
+                                }
+                            }
+                        )
                     }
                 }
             }
         }
     }
 }
+

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/viewmodel/QuizViewModel.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/viewmodel/QuizViewModel.kt
@@ -55,16 +55,36 @@ class QuizViewModel : ViewModel() {
             name = "Capital Cities",
             author = "Alice",
             questions = listOf(
-                Question("Capital of France?", "Paris"),
-                Question("Capital of Spain?", "Madrid")
+                Question(
+                    text = "Capital of France?",
+                    answer = "Paris",
+                    topic = "Geography",
+                    subtopic = "Europe"
+                ),
+                Question(
+                    text = "Capital of Spain?",
+                    answer = "Madrid",
+                    topic = "Geography",
+                    subtopic = "Europe"
+                )
             )
         ),
         PublicQuiz(
             name = "Math Basics",
             author = "Bob",
             questions = listOf(
-                Question("2 + 2?", "4"),
-                Question("5 * 3?", "15")
+                Question(
+                    text = "2 + 2?",
+                    answer = "4",
+                    topic = "Arithmetic",
+                    subtopic = "Addition"
+                ),
+                Question(
+                    text = "5 * 3?",
+                    answer = "15",
+                    topic = "Arithmetic",
+                    subtopic = "Multiplication"
+                )
             )
         )
     )
@@ -340,6 +360,23 @@ class QuizViewModel : ViewModel() {
         } else {
             if (currentQuestionIndex >= box.size) currentQuestionIndex = 0
             return true
+        }
+    }
+
+    /** Updates the question at the given box and index */
+    fun editQuestion(boxIndex: Int, questionIndex: Int, newQuestion: Question) {
+        val box = boxes.getOrNull(boxIndex) ?: return
+        if (questionIndex in box.indices) {
+            box[questionIndex] = newQuestion
+        }
+    }
+
+    /** Deletes the question at the specified box and index */
+    fun deleteQuestion(boxIndex: Int, questionIndex: Int) {
+        boxes.getOrNull(boxIndex)?.let { box ->
+            if (questionIndex in box.indices) {
+                box.removeAt(questionIndex)
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- enable question edit/delete capabilities
- show questions with topics and subtopics
- add swipe actions on question list
- update dummy public quiz data with topics

## Testing
- `./gradlew test -q` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872df5b3e94832d978455714b6a7e27