### PR TITLE
Fix splash/auth logo tint

### DIFF
--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/AuthScreen.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/AuthScreen.kt
@@ -21,7 +21,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.MaterialTheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
@@ -71,7 +73,9 @@ fun AuthScreen(
                 painter = painterResource(id = R.drawable.knowledge_logo),
                 contentDescription = null,
                 modifier = Modifier.size(250.dp),
-                colorFilter = ColorFilter.tint(color = MaterialTheme.colors.primary)
+                colorFilter = ColorFilter.tint(
+                    color = if (isSystemInDarkTheme()) Color.White else Color.Black
+                )
             )
             Spacer(Modifier.height(24.dp))
             Text(

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/SplashScreen.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/SplashScreen.kt
@@ -4,8 +4,10 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.MaterialTheme
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
@@ -20,7 +22,9 @@ fun SplashScreen() {
             painter = painterResource(id = R.drawable.knowledge_logo),
             contentDescription = "Knowledge Logo",
             modifier = Modifier.size(350.dp),
-            colorFilter = ColorFilter.tint(color = MaterialTheme.colors.primary)
+            colorFilter = ColorFilter.tint(
+                color = if (isSystemInDarkTheme()) Color.White else Color.Black
+            )
         )
     }
 }


### PR DESCRIPTION
## Summary
- use Material3 theme for splash and auth screens
- tint `knowledge_logo` black in light mode and white in dark mode

## Testing
- `./gradlew test --no-daemon --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68757baaa4b8832d96fd099f0450691e