### PR TITLE
Fix edit question dropdown out of bounds

### DIFF
--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/QuestionListScreen.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/QuestionListScreen.kt
@@ -216,7 +216,9 @@ fun QuestionListScreen(
                                                     onExpandedChange = { expanded = !expanded }
                                                 ) {
                                                     OutlinedTextField(
-                                                        value = selectedIdx?.let { options[it].name } ?: "Seçiniz",
+                                                        value = selectedIdx?.let { idx ->
+                                                            if (idx in options.indices) options[idx].name else ""
+                                                        } ?: "Seçiniz",
                                                         onValueChange = {},
                                                         readOnly = true,
                                                         label = { Text("Başlık ${level + 1}") },


### PR DESCRIPTION
## Summary
- guard against invalid path indices when populating question edit dropdowns

## Testing
- `./gradlew build -x lint -x test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687581b91a90832daab5127a416c11c1