### PR TITLE
Add system theme option

### DIFF
--- a/app/src/main/java/com/cihat/egitim/lottieanimation/MainActivity.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/MainActivity.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import com.cihat.egitim.lottieanimation.ui.theme.ThemeMode
 import androidx.navigation.compose.rememberNavController
 import com.cihat.egitim.lottieanimation.ui.navigation.AppNavHost
 import com.cihat.egitim.lottieanimation.viewmodel.AuthViewModel
@@ -30,8 +31,9 @@ class MainActivity : ComponentActivity() {
             val activity = this@MainActivity
             val navController = rememberNavController()
             var showDialog by remember { mutableStateOf(false) }
+            var themeMode by remember { mutableStateOf(ThemeMode.SYSTEM) }
 
-            LottieAnimationTheme {
+            LottieAnimationTheme(themeMode = themeMode) {
                 if (showDialog) {
                     AlertDialog(
                         onDismissRequest = { showDialog = false },
@@ -49,7 +51,13 @@ class MainActivity : ComponentActivity() {
                     )
                 }
 
-                AppNavHost(navController, authViewModel, quizViewModel)
+                AppNavHost(
+                    navController = navController,
+                    authViewModel = authViewModel,
+                    quizViewModel = quizViewModel,
+                    themeMode = themeMode,
+                    onThemeChange = { themeMode = it }
+                )
                 BackHandler(enabled = !showDialog) {
                     if (navController.previousBackStackEntry != null) {
                         navController.popBackStack()

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/navigation/AppNavHost.kt
@@ -10,6 +10,7 @@ import androidx.navigation.navArgument
 import com.cihat.egitim.lottieanimation.viewmodel.AuthViewModel
 import com.cihat.egitim.lottieanimation.viewmodel.QuizViewModel
 import com.cihat.egitim.lottieanimation.ui.components.BottomTab
+import com.cihat.egitim.lottieanimation.ui.theme.ThemeMode
 import com.cihat.egitim.lottieanimation.ui.screens.AddQuestionScreen
 import com.cihat.egitim.lottieanimation.ui.screens.AuthScreen
 import com.cihat.egitim.lottieanimation.ui.screens.LoginScreen
@@ -46,7 +47,9 @@ sealed class Screen(val route: String) {
 fun AppNavHost(
     navController: NavHostController,
     authViewModel: AuthViewModel,
-    quizViewModel: QuizViewModel
+    quizViewModel: QuizViewModel,
+    themeMode: ThemeMode,
+    onThemeChange: (ThemeMode) -> Unit
 ) {
     NavHost(navController = navController, startDestination = Screen.Splash.route) {
         composable(Screen.Splash.route) {
@@ -123,6 +126,8 @@ fun AppNavHost(
         }
         composable(Screen.Settings.route) {
             SettingsScreen(
+                themeMode = themeMode,
+                onThemeChange = onThemeChange,
                 onBack = { navController.popBackStack() }
             )
         }

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/SettingsScreen.kt
@@ -2,17 +2,28 @@ package com.cihat.egitim.lottieanimation.ui.screens
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DarkMode
+import androidx.compose.material.icons.filled.LightMode
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.cihat.egitim.lottieanimation.ui.components.AppScaffold
+import com.cihat.egitim.lottieanimation.ui.theme.ThemeMode
 
 @Composable
 fun SettingsScreen(
+    themeMode: ThemeMode,
+    onThemeChange: (ThemeMode) -> Unit,
     onBack: () -> Unit
 ) {
     AppScaffold(
@@ -27,7 +38,30 @@ fun SettingsScreen(
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Text("Settings")
+            Text("Tema")
+            Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                IconButton(onClick = { onThemeChange(ThemeMode.LIGHT) }) {
+                    Icon(
+                        Icons.Default.LightMode,
+                        contentDescription = "Light",
+                        tint = if (themeMode == ThemeMode.LIGHT) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onBackground
+                    )
+                }
+                IconButton(onClick = { onThemeChange(ThemeMode.DARK) }) {
+                    Icon(
+                        Icons.Default.DarkMode,
+                        contentDescription = "Dark",
+                        tint = if (themeMode == ThemeMode.DARK) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onBackground
+                    )
+                }
+                IconButton(onClick = { onThemeChange(ThemeMode.SYSTEM) }) {
+                    Icon(
+                        Icons.Default.Settings,
+                        contentDescription = "System",
+                        tint = if (themeMode == ThemeMode.SYSTEM) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onBackground
+                    )
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/theme/Theme.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/theme/Theme.kt
@@ -5,6 +5,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import com.cihat.egitim.lottieanimation.ui.theme.ThemeMode
 
 private val DarkColorScheme = darkColorScheme(
     primary = DarkPrimary,
@@ -45,12 +46,16 @@ private val LightColorScheme = lightColorScheme(
 )
 
 @Composable
-
 fun LottieAnimationTheme(
-    darkTheme: Boolean = isSystemInDarkTheme(),
+    themeMode: ThemeMode = ThemeMode.SYSTEM,
     content: @Composable () -> Unit
 ) {
-    val colorScheme = if (darkTheme) DarkColorScheme else LightColorScheme
+    val isDark = when (themeMode) {
+        ThemeMode.DARK -> true
+        ThemeMode.LIGHT -> false
+        ThemeMode.SYSTEM -> isSystemInDarkTheme()
+    }
+    val colorScheme = if (isDark) DarkColorScheme else LightColorScheme
 
     MaterialTheme(
         colorScheme = colorScheme,

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/theme/ThemeMode.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/theme/ThemeMode.kt
@@ -1,0 +1,7 @@
+package com.cihat.egitim.lottieanimation.ui.theme
+
+enum class ThemeMode {
+    LIGHT,
+    DARK,
+    SYSTEM
+}


### PR DESCRIPTION
## Summary
- add `ThemeMode` enum
- update `LottieAnimationTheme` to select colors according to `ThemeMode`
- hold selected theme in `MainActivity`
- pass theme through `AppNavHost` and `SettingsScreen`
- allow users to choose Light/Dark/System theme in settings

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876c782eb64832db275fd6dec16cd5b