### PR TITLE
Add network checks for login and Google auth

### DIFF
--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/components/ConnectionAlert.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/components/ConnectionAlert.kt
@@ -29,12 +29,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.foundation.isSystemInDarkTheme
+
 
 @Composable
 fun ConnectionAlert(message: String, onDismiss: () -> Unit, modifier: Modifier = Modifier) {
     val scheme = MaterialTheme.colorScheme
-    val isDark = isSystemInDarkTheme()
 
     val cardBg = scheme.surface
     val cardContent = scheme.onSurface
@@ -66,14 +65,14 @@ fun ConnectionAlert(message: String, onDismiss: () -> Unit, modifier: Modifier =
                         fontWeight = FontWeight.Bold,
                         color = cardContent
                     )
-                    Spacer(Modifier.size(12.dp))
+                    Spacer(Modifier.height(12.dp))
                     Text(
                         message,
                         style = MaterialTheme.typography.bodyMedium,
                         textAlign = TextAlign.Center,
                         color = cardContent
                     )
-                    Spacer(Modifier.size(24.dp))
+                    Spacer(Modifier.height(24.dp))
                     Row(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.Center

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/components/ConnectionAlert.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/components/ConnectionAlert.kt
@@ -1,0 +1,106 @@
+package com.cihat.egitim.lottieanimation.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.isSystemInDarkTheme
+
+@Composable
+fun ConnectionAlert(message: String, onDismiss: () -> Unit, modifier: Modifier = Modifier) {
+    val scheme = MaterialTheme.colorScheme
+    val isDark = isSystemInDarkTheme()
+
+    val cardBg = scheme.surface
+    val cardContent = scheme.onSurface
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .clickable(onClick = onDismiss),
+        contentAlignment = Alignment.Center
+    ) {
+        Box(
+            modifier = Modifier
+                .padding(horizontal = 32.dp)
+                .wrapContentHeight()
+        ) {
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(16.dp),
+                elevation = CardDefaults.cardElevation(defaultElevation = 8.dp),
+                colors = CardDefaults.cardColors(containerColor = cardBg)
+            ) {
+                Column(
+                    modifier = Modifier.padding(top = 48.dp, bottom = 24.dp, start = 24.dp, end = 24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Text(
+                        "Uyarı",
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.Bold,
+                        color = cardContent
+                    )
+                    Spacer(Modifier.size(12.dp))
+                    Text(
+                        message,
+                        style = MaterialTheme.typography.bodyMedium,
+                        textAlign = TextAlign.Center,
+                        color = cardContent
+                    )
+                    Spacer(Modifier.size(24.dp))
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.Center
+                    ) {
+                        TextButton(onClick = onDismiss) {
+                            Text("Kapat", color = cardContent)
+                        }
+                    }
+                }
+            }
+
+            Box(
+                modifier = Modifier
+                    .size(88.dp)
+                    .align(Alignment.TopCenter)
+                    .offset(y = (-44).dp)
+                    .background(MaterialTheme.colorScheme.primary, CircleShape)
+                    .border(4.dp, MaterialTheme.colorScheme.background, CircleShape),
+                contentAlignment = Alignment.Center
+            ) {
+                androidx.compose.material3.Icon(
+                    imageVector = Icons.Default.Info,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onPrimary,
+                    modifier = Modifier.size(40.dp)
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/components/PrimaryAlert.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/components/PrimaryAlert.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/components/PrimaryAlert.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/components/PrimaryAlert.kt
@@ -18,6 +18,8 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Info
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
@@ -30,9 +32,15 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 
-
 @Composable
-fun ConnectionAlert(message: String, onDismiss: () -> Unit, modifier: Modifier = Modifier) {
+fun PrimaryAlert(
+    title: String,
+    message: String,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+    confirmText: String? = null,
+    onConfirm: (() -> Unit)? = null,
+) {
     val scheme = MaterialTheme.colorScheme
 
     val cardBg = scheme.surface
@@ -60,7 +68,7 @@ fun ConnectionAlert(message: String, onDismiss: () -> Unit, modifier: Modifier =
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
                     Text(
-                        "Uyarı",
+                        title,
                         style = MaterialTheme.typography.titleLarge,
                         fontWeight = FontWeight.Bold,
                         color = cardContent
@@ -75,10 +83,21 @@ fun ConnectionAlert(message: String, onDismiss: () -> Unit, modifier: Modifier =
                     Spacer(Modifier.height(24.dp))
                     Row(
                         modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.Center
+                        horizontalArrangement = if (onConfirm != null) Arrangement.SpaceBetween else Arrangement.Center
                     ) {
                         TextButton(onClick = onDismiss) {
                             Text("Kapat", color = cardContent)
+                        }
+                        if (onConfirm != null && confirmText != null) {
+                            Button(
+                                onClick = onConfirm,
+                                colors = ButtonDefaults.buttonColors(
+                                    containerColor = MaterialTheme.colorScheme.primary,
+                                    contentColor = MaterialTheme.colorScheme.onPrimary
+                                )
+                            ) {
+                                Text(confirmText)
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/navigation/AppNavHost.kt
@@ -76,8 +76,9 @@ fun AppNavHost(
         }
         composable(Screen.Login.route) {
             LoginScreen(
-                onLogin = { email, pass ->
+                onLogin = { email, pass, result ->
                     authViewModel.login(email, pass) { success ->
+                        result(success)
                         if (success) {
                             navController.navigate(Screen.QuizList.route) {
                                 popUpTo(Screen.Login.route) { inclusive = true }

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/AuthScreen.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/AuthScreen.kt
@@ -41,7 +41,7 @@ import androidx.compose.material.icons.filled.PersonAdd
 import androidx.compose.ui.graphics.ColorFilter
 import com.cihat.egitim.lottieanimation.R
 import com.cihat.egitim.lottieanimation.ui.components.AppScaffold
-import com.cihat.egitim.lottieanimation.ui.components.ConnectionAlert
+import com.cihat.egitim.lottieanimation.ui.components.PrimaryAlert
 import com.cihat.egitim.lottieanimation.utils.NetworkUtils
 
 @Composable
@@ -145,7 +145,11 @@ fun AuthScreen(
             }
 
             if (showError) {
-                ConnectionAlert("İnternet bağlantınızı kontrol ediniz", onDismiss = { showError = false })
+                PrimaryAlert(
+                    title = "Uyarı",
+                    message = "İnternet bağlantınızı kontrol ediniz",
+                    onDismiss = { showError = false }
+                )
             }
         }
     }

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/AuthScreen.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/AuthScreen.kt
@@ -65,13 +65,14 @@ fun AuthScreen(
         showBack = true,
         onBack = onBack
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(32.dp),
-            verticalArrangement = Arrangement.Center,
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
+        Box(modifier = Modifier.fillMaxSize()) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(32.dp),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
             Image(
                 painter = painterResource(id = R.drawable.knowledge_logo),
                 contentDescription = null,
@@ -139,9 +140,10 @@ fun AuthScreen(
                 Text("Google ile Giriş Yap")
             }
 
-            if (isLoading) {
-                Spacer(Modifier.height(16.dp))
-                CircularProgressIndicator()
+                if (isLoading) {
+                    Spacer(Modifier.height(16.dp))
+                    CircularProgressIndicator()
+                }
             }
 
             if (showError) {

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/AuthScreen.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/AuthScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.Box
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
@@ -140,19 +141,24 @@ fun AuthScreen(
                 Text("Google ile Giriş Yap")
             }
 
-                if (isLoading) {
-                    Spacer(Modifier.height(16.dp))
-                    CircularProgressIndicator()
-                }
-            }
+        }
 
-            if (showError) {
-                PrimaryAlert(
-                    title = "Uyarı",
-                    message = "İnternet bağlantınızı kontrol ediniz",
-                    onDismiss = { showError = false }
-                )
+        if (isLoading) {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator()
             }
+        }
+
+        if (showError) {
+            PrimaryAlert(
+                title = "Uyarı",
+                message = "İnternet bağlantınızı kontrol ediniz",
+                onDismiss = { showError = false }
+            )
+        }
         }
     }
 }

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/LoginScreen.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/LoginScreen.kt
@@ -84,7 +84,9 @@ fun LoginScreen(
                         isLoading = true
                         onLogin(email, password) { success ->
                             isLoading = false
-                            if (!success) showError = true
+                            // Only show the connection error when login failed
+                            // due to missing network rather than auth issues
+                            showError = !success && !NetworkUtils.isConnected(context)
                         }
                     }
                 },

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/LoginScreen.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/LoginScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.platform.LocalContext
 import com.cihat.egitim.lottieanimation.utils.NetworkUtils
 import com.cihat.egitim.lottieanimation.ui.components.PrimaryAlert
 import android.widget.Toast
+import androidx.compose.foundation.layout.Box
 
 @Composable
 fun LoginScreen(

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/LoginScreen.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/LoginScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.ui.platform.LocalContext
 import com.cihat.egitim.lottieanimation.utils.NetworkUtils
 import com.cihat.egitim.lottieanimation.ui.components.PrimaryAlert
+import android.widget.Toast
 
 @Composable
 fun LoginScreen(
@@ -78,7 +79,13 @@ fun LoginScreen(
             Spacer(modifier = Modifier.height(16.dp))
             Button(
                 onClick = {
-                    if (!NetworkUtils.isConnected(context)) {
+                    if (email.isBlank() || password.isBlank()) {
+                        android.widget.Toast.makeText(
+                            context,
+                            "Lütfen e-posta ve şifre giriniz",
+                            android.widget.Toast.LENGTH_SHORT
+                        ).show()
+                    } else if (!NetworkUtils.isConnected(context)) {
                         showError = true
                     } else {
                         isLoading = true

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/LoginScreen.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/LoginScreen.kt
@@ -110,31 +110,35 @@ fun LoginScreen(
                     .padding(4.dp)
             )
             Spacer(modifier = Modifier.height(16.dp))
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Text("Henüz hesabınız yok mu?")
-            Spacer(Modifier.width(4.dp))
-            Text(
-                text = "Kaydol",
-                color = MaterialTheme.colorScheme.primary,
-                modifier = Modifier
-                    .clickable(onClick = onSignup)
-                    .padding(4.dp)
-            )
-        }
-
-                if (isLoading) {
-                    Spacer(modifier = Modifier.height(16.dp))
-                    CircularProgressIndicator()
-                }
-            }
-
-            if (showError) {
-                PrimaryAlert(
-                    title = "Uyarı",
-                    message = "İnternet bağlantınızı kontrol ediniz",
-                    onDismiss = { showError = false }
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text("Henüz hesabınız yok mu?")
+                Spacer(Modifier.width(4.dp))
+                Text(
+                    text = "Kaydol",
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier
+                        .clickable(onClick = onSignup)
+                        .padding(4.dp)
                 )
             }
+        }
+
+        if (isLoading) {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator()
+            }
+        }
+
+        if (showError) {
+            PrimaryAlert(
+                title = "Uyarı",
+                message = "İnternet bağlantınızı kontrol ediniz",
+                onDismiss = { showError = false }
+            )
+        }
         }
     }
 }

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/LoginScreen.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/LoginScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.MaterialTheme
@@ -28,16 +29,22 @@ import androidx.compose.material.icons.filled.Email
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.width
+import androidx.compose.ui.platform.LocalContext
+import com.cihat.egitim.lottieanimation.utils.NetworkUtils
+import com.cihat.egitim.lottieanimation.ui.components.ConnectionAlert
 
 @Composable
 fun LoginScreen(
-    onLogin: (String, String) -> Unit,
+    onLogin: (String, String, (Boolean) -> Unit) -> Unit,
     onBack: () -> Unit,
     onForgot: () -> Unit,
     onSignup: () -> Unit
 ) {
     var email by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
+    var isLoading by remember { mutableStateOf(false) }
+    var showError by remember { mutableStateOf(false) }
+    val context = LocalContext.current
 
     AppScaffold(
         title = "Giriş Yap",
@@ -69,7 +76,17 @@ fun LoginScreen(
             )
             Spacer(modifier = Modifier.height(16.dp))
             Button(
-                onClick = { onLogin(email, password) },
+                onClick = {
+                    if (!NetworkUtils.isConnected(context)) {
+                        showError = true
+                    } else {
+                        isLoading = true
+                        onLogin(email, password) { success ->
+                            isLoading = false
+                            if (!success) showError = true
+                        }
+                    }
+                },
                 modifier = Modifier.fillMaxWidth()
             ) {
                 Text("Giriş Yap")
@@ -83,17 +100,26 @@ fun LoginScreen(
                     .padding(4.dp)
             )
             Spacer(modifier = Modifier.height(16.dp))
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Text("Henüz hesabınız yok mu?")
-                Spacer(Modifier.width(4.dp))
-                Text(
-                    text = "Kaydol",
-                    color = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier
-                        .clickable(onClick = onSignup)
-                        .padding(4.dp)
-                )
-            }
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text("Henüz hesabınız yok mu?")
+            Spacer(Modifier.width(4.dp))
+            Text(
+                text = "Kaydol",
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier
+                    .clickable(onClick = onSignup)
+                    .padding(4.dp)
+            )
+        }
+
+        if (isLoading) {
+            Spacer(modifier = Modifier.height(16.dp))
+            CircularProgressIndicator()
+        }
+
+        if (showError) {
+            ConnectionAlert("İnternet bağlantınızı kontrol ediniz", onDismiss = { showError = false })
         }
     }
+}
 }

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/LoginScreen.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/LoginScreen.kt
@@ -51,13 +51,14 @@ fun LoginScreen(
         showBack = true,
         onBack = onBack
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(16.dp),
-            verticalArrangement = Arrangement.Center,
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
+        Box(modifier = Modifier.fillMaxSize()) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(16.dp),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
             OutlinedTextField(
                 value = email,
                 onValueChange = { email = it },
@@ -112,18 +113,19 @@ fun LoginScreen(
             )
         }
 
-        if (isLoading) {
-            Spacer(modifier = Modifier.height(16.dp))
-            CircularProgressIndicator()
-        }
+                if (isLoading) {
+                    Spacer(modifier = Modifier.height(16.dp))
+                    CircularProgressIndicator()
+                }
+            }
 
-        if (showError) {
-            PrimaryAlert(
-                title = "Uyarı",
-                message = "İnternet bağlantınızı kontrol ediniz",
-                onDismiss = { showError = false }
-            )
+            if (showError) {
+                PrimaryAlert(
+                    title = "Uyarı",
+                    message = "İnternet bağlantınızı kontrol ediniz",
+                    onDismiss = { showError = false }
+                )
+            }
         }
     }
-}
 }

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/LoginScreen.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/LoginScreen.kt
@@ -31,7 +31,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.width
 import androidx.compose.ui.platform.LocalContext
 import com.cihat.egitim.lottieanimation.utils.NetworkUtils
-import com.cihat.egitim.lottieanimation.ui.components.ConnectionAlert
+import com.cihat.egitim.lottieanimation.ui.components.PrimaryAlert
 
 @Composable
 fun LoginScreen(
@@ -118,7 +118,11 @@ fun LoginScreen(
         }
 
         if (showError) {
-            ConnectionAlert("İnternet bağlantınızı kontrol ediniz", onDismiss = { showError = false })
+            PrimaryAlert(
+                title = "Uyarı",
+                message = "İnternet bağlantınızı kontrol ediniz",
+                onDismiss = { showError = false }
+            )
         }
     }
 }

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/QuizListScreen.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/QuizListScreen.kt
@@ -78,6 +78,7 @@ import com.cihat.egitim.lottieanimation.data.UserQuiz
 import com.cihat.egitim.lottieanimation.data.UserFolder
 import com.cihat.egitim.lottieanimation.ui.components.AppScaffold
 import com.cihat.egitim.lottieanimation.ui.components.BottomTab
+import com.cihat.egitim.lottieanimation.ui.components.PrimaryAlert
 import com.cihat.egitim.lottieanimation.data.FolderHeading
 import com.cihat.egitim.lottieanimation.data.Question
 import kotlinx.coroutines.launch
@@ -596,7 +597,10 @@ fun QuizListScreen(
 
         if (showWarning) {
             PrimaryAlert(
+                title = "Uyarı",
+                message = "Quiz oluşturmak için klasör oluşturunuz.",
                 onDismiss = { showWarning = false },
+                confirmText = "Klasör Oluştur",
                 onConfirm = {
                     showWarning = false
                     onFolders()
@@ -632,94 +636,4 @@ fun QuizListScreen(
     }
 }
 
-@Composable
-fun PrimaryAlert(
-    onDismiss: () -> Unit,
-    onConfirm: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    val scheme = MaterialTheme.colorScheme
-    val isDark = isSystemInDarkTheme()
-
-    val cardBg = scheme.surface
-    val cardContent = scheme.onSurface
-
-    val badgeBg = if (isDark) scheme.primary else scheme.secondary
-    val badgeBorder = scheme.background   // 4 dp’lik kenar
-
-    Box(
-        modifier = modifier
-            .fillMaxSize()
-            .clickable(onClick = onDismiss),
-        contentAlignment = Alignment.Center
-    ) {
-        Box(
-            modifier = Modifier
-                .padding(horizontal = 32.dp)
-                .wrapContentHeight()
-        ) {
-            Card(
-                modifier = Modifier.fillMaxWidth(),
-                shape = RoundedCornerShape(16.dp),
-                elevation = CardDefaults.cardElevation(defaultElevation = 8.dp),
-                colors = CardDefaults.cardColors(containerColor = cardBg)
-            ) {
-                Column(
-                    modifier = Modifier.padding(top = 48.dp, bottom = 24.dp, start = 24.dp, end = 24.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-                    Text(
-                        "Uyarı",
-                        style = MaterialTheme.typography.titleLarge,
-                        fontWeight = FontWeight.Bold,
-                        color = cardContent
-                    )
-                    Spacer(Modifier.height(12.dp))
-                    Text(
-                        "Quiz oluşturmak için klasör oluşturunuz.",
-                        style = MaterialTheme.typography.bodyMedium,
-                        textAlign = TextAlign.Center,
-                        color = cardContent
-                    )
-                    Spacer(Modifier.height(24.dp))
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween
-                    ) {
-                        TextButton(onClick = onDismiss) {
-                            Text("Kapat", color = cardContent)
-                        }
-                        Button(
-                            onClick = onConfirm,
-                            colors = ButtonDefaults.buttonColors(
-                                containerColor = MaterialTheme.colorScheme.primary,
-                                contentColor = MaterialTheme.colorScheme.onPrimary
-                            )
-                        ) {
-                            Text("Klasör Oluştur")
-                        }
-                    }
-                }
-            }
-
-            /* Üst rozeti */
-            Box(
-                modifier = Modifier
-                    .size(88.dp)
-                    .align(Alignment.TopCenter)
-                    .offset(y = (-44).dp)
-                    .background(MaterialTheme.colorScheme.primary, CircleShape)
-                    .border(4.dp, MaterialTheme.colorScheme.background, CircleShape),
-                contentAlignment = Alignment.Center
-            ) {
-                Icon(                                   // ister Icon yerine Image kullan
-                    imageVector = Icons.Default.Info,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onPrimary,
-                    modifier = Modifier.size(40.dp)
-                )
-            }
-        }
-    }
-}
 

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/utils/NetworkUtils.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/utils/NetworkUtils.kt
@@ -1,0 +1,14 @@
+package com.cihat.egitim.lottieanimation.utils
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+
+object NetworkUtils {
+    fun isConnected(context: Context): Boolean {
+        val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        val network = cm.activeNetwork ?: return false
+        val capabilities = cm.getNetworkCapabilities(network) ?: return false
+        return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+    }
+}

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/viewmodel/AuthViewModel.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/viewmodel/AuthViewModel.kt
@@ -1,6 +1,7 @@
 package com.cihat.egitim.lottieanimation.viewmodel
 
 import android.content.Context
+import com.cihat.egitim.lottieanimation.utils.NetworkUtils
 import androidx.lifecycle.ViewModel
 import com.firebase.ui.auth.AuthUI
 import com.google.firebase.auth.FirebaseAuth
@@ -18,7 +19,11 @@ class AuthViewModel : ViewModel() {
             .addOnCompleteListener { onResult(it.isSuccessful) }
     }
 
-    fun register(email: String, password: String, onResult: (Boolean) -> Unit) {
+    fun register(context: Context, email: String, password: String, onResult: (Boolean) -> Unit) {
+        if (!NetworkUtils.isConnected(context)) {
+            onResult(false)
+            return
+        }
         auth.createUserWithEmailAndPassword(email, password)
             .addOnCompleteListener { onResult(it.isSuccessful) }
     }

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/viewmodel/AuthViewModel.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/viewmodel/AuthViewModel.kt
@@ -15,6 +15,10 @@ class AuthViewModel : ViewModel() {
         get() = auth.currentUser
 
     fun login(email: String, password: String, onResult: (Boolean) -> Unit) {
+        if (email.isBlank() || password.isBlank()) {
+            onResult(false)
+            return
+        }
         auth.signInWithEmailAndPassword(email, password)
             .addOnCompleteListener { onResult(it.isSuccessful) }
     }


### PR DESCRIPTION
## Summary
- add `NetworkUtils` for checking internet connectivity
- add `ConnectionAlert` composable for connection error prompts
- show loader and connection warnings in `LoginScreen` and `AuthScreen`
- wire callback for login result in `AppNavHost`
- validate network before registration

## Testing
- `./gradlew tasks --all`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879368472ac832da7df737e6c59b4e5