### PR TITLE
Add account tab to bottom bar

### DIFF
--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/components/AppScaffold.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/components/AppScaffold.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material3.CenterAlignedTopAppBar
@@ -20,7 +21,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.ui.Modifier
 
-enum class BottomTab { PROFILE, HOME, EXPLORE }
+enum class BottomTab { PROFILE, HOME, EXPLORE, ACCOUNT }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -53,8 +54,8 @@ fun AppScaffold(
                     NavigationBarItem(
                         selected = tab == BottomTab.PROFILE,
                         onClick = { onTabSelected(BottomTab.PROFILE) },
-                        icon = { Icon(Icons.Default.Person, contentDescription = "Profile") },
-                        label = { Text("Profile") }
+                        icon = { Icon(Icons.Default.Menu, contentDescription = "Menu") },
+                        label = { Text("Menu") }
                     )
                     NavigationBarItem(
                         selected = tab == BottomTab.HOME,
@@ -67,6 +68,12 @@ fun AppScaffold(
                         onClick = { onTabSelected(BottomTab.EXPLORE) },
                         icon = { Icon(Icons.Default.Search, contentDescription = "Explore") },
                         label = { Text("Explore") }
+                    )
+                    NavigationBarItem(
+                        selected = tab == BottomTab.ACCOUNT,
+                        onClick = { onTabSelected(BottomTab.ACCOUNT) },
+                        icon = { Icon(Icons.Default.Person, contentDescription = "Profile") },
+                        label = { Text("Profile") }
                     )
                 }
             }

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/navigation/AppNavHost.kt
@@ -18,6 +18,7 @@ import com.cihat.egitim.lottieanimation.ui.screens.HomeFeedScreen
 import com.cihat.egitim.lottieanimation.ui.screens.FolderListScreen
 import com.cihat.egitim.lottieanimation.ui.screens.ProfileScreen
 import com.cihat.egitim.lottieanimation.ui.screens.UserProfileScreen
+import com.cihat.egitim.lottieanimation.ui.screens.AccountScreen
 import com.cihat.egitim.lottieanimation.ui.screens.QuestionListScreen
 import com.cihat.egitim.lottieanimation.ui.screens.QuizListScreen
 import com.cihat.egitim.lottieanimation.ui.screens.QuizScreen
@@ -34,6 +35,7 @@ sealed class Screen(val route: String) {
     data object FolderList : Screen("folderList")
     data object Profile : Screen("profile")
     data object MyProfile : Screen("myProfile")
+    data object Account : Screen("account")
     data object BoxList : Screen("boxList")
     data object HomeFeed : Screen("homeFeed")
     data object Quiz : Screen("quiz")
@@ -119,6 +121,7 @@ fun AppNavHost(
                             BottomTab.PROFILE -> navController.navigate(Screen.Profile.route)
                             BottomTab.HOME -> navController.navigate(Screen.QuizList.route)
                             BottomTab.EXPLORE -> navController.navigate(Screen.HomeFeed.route)
+                            BottomTab.ACCOUNT -> navController.navigate(Screen.Account.route)
                         }
                     }
             )
@@ -127,6 +130,21 @@ fun AppNavHost(
             UserProfileScreen(
                 user = authViewModel.currentUser,
                 onBack = { navController.popBackStack() }
+            )
+        }
+        composable(Screen.Account.route) {
+            val canPop = navController.previousBackStackEntry != null
+            AccountScreen(
+                showBack = canPop,
+                onBack = { navController.popBackStack() },
+                onTab = { tab ->
+                    when (tab) {
+                        BottomTab.PROFILE -> navController.navigate(Screen.Profile.route)
+                        BottomTab.HOME -> navController.navigate(Screen.QuizList.route)
+                        BottomTab.EXPLORE -> navController.navigate(Screen.HomeFeed.route)
+                        BottomTab.ACCOUNT -> navController.navigate(Screen.Account.route)
+                    }
+                }
             )
         }
         composable(Screen.Settings.route) {
@@ -151,6 +169,7 @@ fun AppNavHost(
                             BottomTab.PROFILE -> navController.navigate(Screen.Profile.route)
                             BottomTab.HOME -> navController.navigate(Screen.QuizList.route)
                             BottomTab.EXPLORE -> navController.navigate(Screen.HomeFeed.route)
+                            BottomTab.ACCOUNT -> navController.navigate(Screen.Account.route)
                         }
                     }
             )
@@ -195,6 +214,7 @@ fun AppNavHost(
                         BottomTab.PROFILE -> navController.navigate(Screen.Profile.route)
                         BottomTab.HOME -> navController.navigate(Screen.QuizList.route)
                         BottomTab.EXPLORE -> navController.navigate(Screen.HomeFeed.route)
+                        BottomTab.ACCOUNT -> navController.navigate(Screen.Account.route)
                     }
                 }
             )
@@ -232,6 +252,7 @@ fun AppNavHost(
                         BottomTab.PROFILE -> navController.navigate(Screen.Profile.route)
                         BottomTab.HOME -> navController.navigate(Screen.QuizList.route)
                         BottomTab.EXPLORE -> navController.navigate(Screen.HomeFeed.route)
+                        BottomTab.ACCOUNT -> navController.navigate(Screen.Account.route)
                     }
                 }
             )
@@ -256,6 +277,7 @@ fun AppNavHost(
                         BottomTab.PROFILE -> navController.navigate(Screen.Profile.route)
                         BottomTab.HOME -> navController.navigate(Screen.QuizList.route)
                         BottomTab.EXPLORE -> {}
+                        BottomTab.ACCOUNT -> navController.navigate(Screen.Account.route)
                     }
                 }
             )

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/AccountScreen.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/AccountScreen.kt
@@ -1,0 +1,29 @@
+package com.cihat.egitim.lottieanimation.ui.screens
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.material3.Text
+import com.cihat.egitim.lottieanimation.ui.components.AppScaffold
+import com.cihat.egitim.lottieanimation.ui.components.BottomTab
+
+@Composable
+fun AccountScreen(
+    showBack: Boolean,
+    onBack: () -> Unit,
+    onTab: (BottomTab) -> Unit
+) {
+    AppScaffold(
+        title = "Profile",
+        showBack = showBack,
+        onBack = onBack,
+        bottomTab = BottomTab.ACCOUNT,
+        onTabSelected = onTab
+    ) {
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Text("Profile Page")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add new `ACCOUNT` enum to `BottomTab`
- replace leftmost icon with a menu icon
- add a placeholder `AccountScreen`
- wire new `Account` route in navigation and bottom bar

## Testing
- `./gradlew --no-daemon tasks --all`

------
https://chatgpt.com/codex/tasks/task_e_688157ca0614832d9b0cbf3b150a7a77