### PR TITLE
Display quiz owner info

### DIFF
--- a/app/src/main/java/com/cihat/egitim/lottieanimation/data/PublicQuiz.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/data/PublicQuiz.kt
@@ -6,5 +6,7 @@ package com.cihat.egitim.lottieanimation.data
 data class PublicQuiz(
     val name: String,
     val author: String,
-    val questions: List<Question>
+    val questions: List<Question>,
+    val authorPhotoUrl: String? = null,
+    val folderName: String? = null
 )

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/navigation/AppNavHost.kt
@@ -201,6 +201,7 @@ fun AppNavHost(
             QuizListScreen(
                 quizzes = quizViewModel.quizzes,
                 folders = quizViewModel.folders,
+                currentUser = authViewModel.currentUser,
                 onQuiz = { quizIdx, boxIdx ->
                     quizViewModel.setCurrentQuiz(quizIdx)
                     if (quizViewModel.startQuiz(boxIdx)) {

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/HomeFeedScreen.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/HomeFeedScreen.kt
@@ -7,10 +7,19 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.ui.draw.clip
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
 import com.cihat.egitim.lottieanimation.data.PublicQuiz
 import com.cihat.egitim.lottieanimation.ui.components.AppScaffold
 import com.cihat.egitim.lottieanimation.ui.components.BottomTab
@@ -41,14 +50,36 @@ fun HomeFeedScreen(
         ) {
             LazyColumn(modifier = Modifier.weight(1f)) {
                 itemsIndexed(quizzes) { index, quiz ->
-                    Column(
+                    Card(
                         modifier = Modifier
-                            .fillMaxSize()
-                            .padding(vertical = 8.dp)
+                            .fillMaxWidth()
+                            .padding(vertical = 8.dp),
+                        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
                     ) {
-                        Text(text = "${quiz.name} - by ${quiz.author}")
-                        Text(text = "${quiz.questions.size} questions")
-                        Button(onClick = { onImport(index) }) { Text("Import") }
+                        Column(modifier = Modifier.padding(8.dp)) {
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                quiz.authorPhotoUrl?.let { url ->
+                                    AsyncImage(
+                                        model = url,
+                                        contentDescription = null,
+                                        modifier = Modifier
+                                            .size(40.dp)
+                                            .clip(CircleShape)
+                                    )
+                                    Spacer(Modifier.width(8.dp))
+                                }
+                                Column(modifier = Modifier.weight(1f)) {
+                                    Text(quiz.author)
+                                    quiz.folderName?.let { Text(it) }
+                                }
+                                Button(onClick = { onImport(index) }) { Text("Import") }
+                            }
+                            Text(
+                                text = quiz.name,
+                                modifier = Modifier.padding(top = 4.dp)
+                            )
+                            Text(text = "${quiz.questions.size} questions")
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/QuizListScreen.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/QuizListScreen.kt
@@ -48,6 +48,8 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import coil.compose.AsyncImage
+import com.google.firebase.auth.FirebaseUser
 import androidx.compose.ui.graphics.Color
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -114,6 +116,7 @@ private fun headingsFromQuestions(questions: List<Question>): List<FolderHeading
 fun QuizListScreen(
     quizzes: List<UserQuiz>,
     folders: List<UserFolder>,
+    currentUser: FirebaseUser?,
     onQuiz: (Int, Int) -> Unit,
     onView: (Int, Int) -> Unit,
     onRename: (Int, String) -> Unit,
@@ -349,14 +352,34 @@ fun QuizListScreen(
                                     .fillMaxWidth()
                                     .padding(vertical = 8.dp)
                             ) {
+                                val folderName = folders.find { it.id == quiz.folderId }?.name ?: ""
                                 Row(
                                     modifier = Modifier
                                         .fillMaxWidth()
-                                        .height(64.dp)
+                                        .height(72.dp)
                                         .padding(horizontal = 8.dp),
                                     verticalAlignment = Alignment.CenterVertically
                                 ) {
-                                    Text(text = quiz.name, modifier = Modifier.weight(1f))
+                                    Row(
+                                        modifier = Modifier.weight(1f),
+                                        verticalAlignment = Alignment.CenterVertically
+                                    ) {
+                                        currentUser?.photoUrl?.let { url ->
+                                            AsyncImage(
+                                                model = url,
+                                                contentDescription = null,
+                                                modifier = Modifier
+                                                    .size(40.dp)
+                                                    .clip(CircleShape)
+                                            )
+                                            Spacer(Modifier.width(8.dp))
+                                        }
+                                        Column {
+                                            Text(currentUser?.displayName ?: "")
+                                            Text(folderName)
+                                            Text(quiz.name)
+                                        }
+                                    }
                                     FilledIconButton(
                                         onClick = { expanded = !expanded },
                                         enabled = kotlin.math.abs(swipeState.offset.value) < 1f,

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/viewmodel/QuizViewModel.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/viewmodel/QuizViewModel.kt
@@ -135,6 +135,9 @@ class QuizViewModel(private val repository: LocalRepository) : ViewModel() {
                     subtopic = "Europe"
                 )
             )
+            ),
+            authorPhotoUrl = "https://example.com/alice.png",
+            folderName = "Geography"
         ),
         PublicQuiz(
             name = "Math Basics",
@@ -152,7 +155,9 @@ class QuizViewModel(private val repository: LocalRepository) : ViewModel() {
                     topic = "Arithmetic",
                     subtopic = "Multiplication"
                 )
-            )
+            ),
+            authorPhotoUrl = "https://example.com/bob.png",
+            folderName = "Math"
         )
     )
 


### PR DESCRIPTION
## Summary
- include author photo URL and folder name in `PublicQuiz`
- show sample quiz owner info in `QuizViewModel`
- pass Firebase user to `QuizListScreen`
- display user photo, username and folder in quiz list
- style explore feed items with author info

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688280c81d4c832da27627e6ef488f98