### PR TITLE
Add public profile screen

### DIFF
--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/navigation/AppNavHost.kt
@@ -13,6 +13,7 @@ import androidx.navigation.NavController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
+import android.net.Uri
 import com.cihat.egitim.lottieanimation.viewmodel.AuthViewModel
 import com.cihat.egitim.lottieanimation.viewmodel.QuizViewModel
 import com.cihat.egitim.lottieanimation.ui.components.BottomTab
@@ -24,6 +25,7 @@ import com.cihat.egitim.lottieanimation.ui.screens.HomeFeedScreen
 import com.cihat.egitim.lottieanimation.ui.screens.FolderListScreen
 import com.cihat.egitim.lottieanimation.ui.screens.ProfileScreen
 import com.cihat.egitim.lottieanimation.ui.screens.UserProfileScreen
+import com.cihat.egitim.lottieanimation.ui.screens.PublicUserProfileScreen
 import com.cihat.egitim.lottieanimation.ui.screens.QuestionListScreen
 import com.cihat.egitim.lottieanimation.ui.screens.QuizListScreen
 import com.cihat.egitim.lottieanimation.ui.screens.QuizScreen
@@ -40,6 +42,17 @@ sealed class Screen(val route: String) {
     data object FolderList : Screen("folderList")
     data object Profile : Screen("profile")
     data object MyProfile : Screen("myProfile")
+    data object PublicProfile : Screen("publicProfile") {
+        const val usernameArg = "username"
+        const val nameArg = "name"
+        const val photoArg = "photo"
+        fun createRoute(username: String, name: String, photoUrl: String?): String {
+            val u = Uri.encode(username)
+            val n = Uri.encode(name)
+            val p = Uri.encode(photoUrl ?: "")
+            return "publicProfile?$usernameArg=$u&$nameArg=$n&$photoArg=$p"
+        }
+    }
     data object BoxList : Screen("boxList")
     data object HomeFeed : Screen("homeFeed")
     data object Quiz : Screen("quiz")
@@ -316,6 +329,15 @@ fun AppNavHost(
                     ).show()
                     navController.navigate(Screen.QuizList.route)
                 },
+                onUser = { quiz ->
+                    navController.navigate(
+                        Screen.PublicProfile.createRoute(
+                            username = quiz.author,
+                            name = quiz.author,
+                            photoUrl = quiz.authorPhotoUrl
+                        )
+                    )
+                },
                 showBack = canPop,
                 onBack = { navController.popBackStack() },
                 bottomTab = currentTab,
@@ -356,6 +378,41 @@ fun AppNavHost(
                 onDelete = { qIdx -> quizViewModel.deleteQuestion(index, qIdx) },
                 onBack = { navController.popBackStack() },
                 onMenu = openDrawer
+            )
+        }
+        composable(
+            route = Screen.PublicProfile.route + "?" +
+                    "${Screen.PublicProfile.usernameArg}={${Screen.PublicProfile.usernameArg}}&" +
+                    "${Screen.PublicProfile.nameArg}={${Screen.PublicProfile.nameArg}}&" +
+                    "${Screen.PublicProfile.photoArg}={${Screen.PublicProfile.photoArg}}",
+            arguments = listOf(
+                navArgument(Screen.PublicProfile.usernameArg) { type = NavType.StringType },
+                navArgument(Screen.PublicProfile.nameArg) { type = NavType.StringType },
+                navArgument(Screen.PublicProfile.photoArg) {
+                    type = NavType.StringType
+                    defaultValue = ""
+                }
+            )
+        ) { backStackEntry ->
+            val username = backStackEntry.arguments?.getString(Screen.PublicProfile.usernameArg) ?: ""
+            val name = backStackEntry.arguments?.getString(Screen.PublicProfile.nameArg) ?: ""
+            val photo = backStackEntry.arguments?.getString(Screen.PublicProfile.photoArg)
+            PublicUserProfileScreen(
+                username = username,
+                fullName = name,
+                photoUrl = photo.takeIf { !it.isNullOrEmpty() },
+                onBack = { navController.popBackStack() },
+                bottomTab = currentTab,
+                onMenu = openDrawer,
+                onTab = { tab ->
+                    closeDrawer()
+                    currentTab = tab
+                    when (tab) {
+                        BottomTab.HOME -> navController.navigate(Screen.QuizList.route)
+                        BottomTab.EXPLORE -> navController.navigate(Screen.HomeFeed.route)
+                        BottomTab.PROFILE -> navController.navigate(Screen.Profile.route)
+                    }
+                }
             )
         }
     }

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/HomeFeedScreen.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/HomeFeedScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.Button
+import androidx.compose.foundation.clickable
 import androidx.compose.material3.Text
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -30,6 +31,7 @@ import com.cihat.egitim.lottieanimation.ui.components.BottomTab
 fun HomeFeedScreen(
     quizzes: List<PublicQuiz>,
     onImport: (Int) -> Unit,
+    onUser: (PublicQuiz) -> Unit,
     showBack: Boolean,
     onBack: () -> Unit,
     bottomTab: BottomTab,
@@ -71,7 +73,10 @@ fun HomeFeedScreen(
                                     Spacer(Modifier.width(8.dp))
                                 }
                                 Column(modifier = Modifier.weight(1f)) {
-                                    Text(quiz.author)
+                                    Text(
+                                        text = quiz.author,
+                                        modifier = Modifier.clickable { onUser(quiz) }
+                                    )
                                     quiz.folderName?.let { Text(it) }
                                 }
                                 Button(onClick = { onImport(index) }) { Text("Import") }

--- a/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/PublicUserProfileScreen.kt
+++ b/app/src/main/java/com/cihat/egitim/lottieanimation/ui/screens/PublicUserProfileScreen.kt
@@ -1,0 +1,56 @@
+package com.cihat.egitim.lottieanimation.ui.screens
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.cihat.egitim.lottieanimation.ui.components.AppScaffold
+import com.cihat.egitim.lottieanimation.ui.components.BottomTab
+
+@Composable
+fun PublicUserProfileScreen(
+    username: String,
+    fullName: String,
+    photoUrl: String?,
+    onBack: () -> Unit,
+    bottomTab: BottomTab,
+    onMenu: () -> Unit,
+    onTab: (BottomTab) -> Unit = {},
+) {
+    AppScaffold(
+        title = username,
+        showBack = true,
+        onBack = onBack,
+        onMenu = onMenu,
+        bottomTab = bottomTab,
+        onTabSelected = onTab
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            photoUrl?.takeIf { it.isNotBlank() }?.let { url ->
+                AsyncImage(
+                    model = url,
+                    contentDescription = null,
+                    modifier = Modifier
+                        .size(80.dp)
+                        .clip(CircleShape)
+                )
+                Spacer(Modifier.size(16.dp))
+            }
+            Text(fullName)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- show list authors clickable in `HomeFeedScreen`
- navigate to a new `PublicUserProfileScreen` when an author is selected
- handle routing with encoded query params in `AppNavHost`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883dc2bac2c832d923da8fdf2c1f7df